### PR TITLE
Webapp > Backend: Use samples for tests

### DIFF
--- a/python-lib/dku_stress_test_center/model_accessor.py
+++ b/python-lib/dku_stress_test_center/model_accessor.py
@@ -1,14 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
-import pandas as pd
-from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier, ExtraTreesClassifier
-from sklearn.tree import DecisionTreeClassifier
+import numpy as np
 from dku_stress_test_center.utils import DkuStressTestCenterConstants
 
 logger = logging.getLogger(__name__)
-
-ALGORITHMS_WITH_VARIABLE_IMPORTANCE = [RandomForestClassifier, GradientBoostingClassifier, ExtraTreesClassifier,
-                                       DecisionTreeClassifier]
 
 
 class ModelAccessor(object):
@@ -32,13 +27,16 @@ class ModelAccessor(object):
         """
         return self.model_handler.get_target_variable()
 
-    def get_original_test_df(self, limit=DkuStressTestCenterConstants.MAX_NUM_ROW):
+    def get_original_test_df(self, sample_fraction, random_state):
+        np.random.seed(random_state)
         try:
-            return self.model_handler.get_test_df()[0][:limit]
+            test_df, _ = self.model_handler.get_test_df()
         except Exception as e:
             logger.warning(
-                'Can not retrieve original test set: {}. The plugin will take the whole original dataset.'.format(e))
-            return self.model_handler.get_full_df()[0][:limit]
+                'Cannot retrieve original test set: {}. The plugin will take the whole original dataset.'.format(e))
+            test_df, _ = self.model_handler.get_full_df()
+        finally:
+            return test_df.sample(frac=sample_fraction, random_state=random_state)
 
     def get_per_feature(self):
         return self.model_handler.get_per_feature()

--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -29,26 +29,24 @@ class StressTestConfiguration(object):
         return StressTestConfiguration(shift, shift_features)
 
 class StressTestGenerator(object):
-    def __init__(self, clean_dataset_size=DkuStressTestCenterConstants.CLEAN_DATASET_NUM_ROWS,
-                random_state=65537):
+    def __init__(self, random_state=65537):
         self.config_list = None
         self.model_accessor = None
-        self.selected_features = None
 
         self._random_state = random_state
-        self._clean_dataset_size = clean_dataset_size
+        self._clean_dataset_size = None
 
-    def set_config(self, shift_configs: dict):
+    def set_config(self, config: dict):
+        self._clean_dataset_size = config["samples"]
+        tests_config = config["perturbations"]
         self.config_list = []
-        for shift_type, shift_config in shift_configs.items():
+        for shift_type, shift_config in tests_config.items():
             params, features = shift_config["params"], shift_config.get("selected_features")
             self.config_list.append(StressTestConfiguration.create_conf(shift_type, params, features))
 
-    def _subsample_clean_df(self,
-                            clean_df: pd.DataFrame):
-
+    def _subsample_clean_df(self, clean_df: pd.DataFrame):
         np.random.seed(self._random_state)
-        return clean_df.sample(n=self._clean_dataset_size, random_state=self._random_state)
+        return clean_df.sample(frac=self._clean_dataset_size, random_state=self._random_state)
 
     def fit_transform(self):
         clean_df = self._subsample_clean_df(self.model_accessor.get_original_test_df())

--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -34,22 +34,19 @@ class StressTestGenerator(object):
         self.model_accessor = None
 
         self._random_state = random_state
-        self._clean_dataset_size = None
+        self._sampling_proportion = None
 
     def set_config(self, config: dict):
-        self._clean_dataset_size = config["samples"]
+        self._sampling_proportion = config["samples"]
         tests_config = config["perturbations"]
         self.config_list = []
         for shift_type, shift_config in tests_config.items():
             params, features = shift_config["params"], shift_config.get("selected_features")
             self.config_list.append(StressTestConfiguration.create_conf(shift_type, params, features))
 
-    def _subsample_clean_df(self, clean_df: pd.DataFrame):
-        np.random.seed(self._random_state)
-        return clean_df.sample(frac=self._clean_dataset_size, random_state=self._random_state)
-
     def fit_transform(self):
-        clean_df = self._subsample_clean_df(self.model_accessor.get_original_test_df())
+        clean_df = self.model_accessor.get_original_test_df(sample_fraction=self._sampling_proportion,
+                                                            random_state=self._random_state)
         target_column = self.model_accessor.get_target_variable()
 
         perturbed_datasets_df = clean_df.copy(deep=True)

--- a/python-lib/dku_stress_test_center/utils.py
+++ b/python-lib/dku_stress_test_center/utils.py
@@ -24,7 +24,6 @@ def get_stress_test_name(shift: Shift):
 
 
 class DkuStressTestCenterConstants(object):
-    CLEAN_DATASET_NUM_ROWS = 500
     CLEAN = 'CLEAN'
     MISSING_VALUES = 'MISSING_VALUES'
     SCALING = 'SCALING'

--- a/python-lib/dku_stress_test_center/utils.py
+++ b/python-lib/dku_stress_test_center/utils.py
@@ -43,8 +43,6 @@ class DkuStressTestCenterConstants(object):
     STRESS_TEST_TYPE = '_dku_stress_test_type'
     DKU_ROW_ID = '_dku_row_identifier_'
 
-    MAX_NUM_ROW = 100000
-
     REGRESSION_TYPE = 'REGRESSION'
     CLASSIFICATION_TYPE = 'CLASSIFICATION'
     CLUSTERING_TYPE = 'CLUSTERING'

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -5,7 +5,7 @@
     </div>
     <form name="forms.SAMPLES" class="settings-subsection__form" ng-submit="runAnalysis()">
         <div class="control-group settings-subsection__form_field">
-            <label for="samples" class="label-text">Samples for stress tests</label>
+            <label for="samples" class="label-text">Proportion of samples for all the stress tests</label>
             <input type="number" id="samples" ng-model="tests.samples" step="0.01" min="0.01" max="1" required>
             <div class="text-tiny">
                 Set the proportion of rows used to run the selected stress tests

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -5,10 +5,10 @@
     </div>
     <form name="forms.SAMPLES" class="settings-subsection__form">
         <div class="control-group settings-subsection__form_field">
-            <label for="samples" class="label-text">Samples for perturbation tests</label>
-            <input type="number" id="samples" ng-model="tests.samples" step="0.1" min="0.1" max="100" required>
+            <label for="samples" class="label-text">Samples for stress tests</label>
+            <input type="number" id="samples" ng-model="tests.samples" step="0.01" min="0.01" max="1" required>
             <div class="text-tiny">
-                Set the percentage of rows to be used for the selected stress tests
+                Set the proportion of rows used to run the selected stress tests
             </div>
         </div>
     </form>
@@ -43,11 +43,11 @@
              possible-values="modelInfo.targetClasses"
              item="tests.perturbations.PRIOR_SHIFT.params.cl"
              item-name="class"
-             label="Affected class"
+             label="Selected class"
              class="settings-subsection__form_field">
         </div>
         <div class="control-group settings-subsection__form_field">
-            <label for="priorShift" class="label-text">Proportion of samples with affected class</label>
+            <label for="priorShift" class="label-text">Desired proportion of samples with selected class</label>
             <input type="number" id="priorShift"
                    ng-model="tests.perturbations.PRIOR_SHIFT.params.samples_fraction"
                    placeholder="0.5" step="0.01" min="0" max="1" required>
@@ -73,11 +73,11 @@
              items="tests.perturbations.MISSING_VALUES.selected_features"
              item-name="feature"
              item-image="featureToTypeIcon"
-             label="Affected features"
+             label="Corrupted features"
              class="settings-subsection__form_field">
         </div>
         <div class="control-group settings-subsection__form_field">
-            <label for="missingValues" class="label-text">Proportion of affected samples</label>
+            <label for="missingValues" class="label-text">Proportion of corrupted samples</label>
             <input type="number" id="missingValues"
                    ng-model="tests.perturbations.MISSING_VALUES.params.samples_fraction"
                    placeholder="0.5" step="0.01" min="0.01" max="1" required>
@@ -103,11 +103,11 @@
              items="tests.perturbations.SCALING.selected_features"
              item-name="feature"
              item-image="featureToTypeIcon"
-             label="Affected features"
+             label="Corrupted features"
              class="settings-subsection__form_field">
         </div>
         <div class="control-group settings-subsection__form_field">
-            <label for="scaling" class="label-text">Proportion of affected samples</label>
+            <label for="scaling" class="label-text">Proportion of corrupted samples</label>
             <input type="number" id="scaling"
                    ng-model="tests.perturbations.SCALING.params.samples_fraction"
                    placeholder="0.5" step="0.01" min="0" max="1" required>

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -3,7 +3,7 @@
         Stress tests
         <help-icon class="small-title-b" help-text="Select the tests corresponding to corruptions you expect to have at deployment time, and assess the robustness of your model"></help-icon>
     </div>
-    <form name="forms.SAMPLES" class="settings-subsection__form">
+    <form name="forms.SAMPLES" class="settings-subsection__form" ng-submit="runAnalysis()">
         <div class="control-group settings-subsection__form_field">
             <label for="samples" class="label-text">Samples for stress tests</label>
             <input type="number" id="samples" ng-model="tests.samples" step="0.01" min="0.01" max="1" required>
@@ -11,15 +11,15 @@
                 Set the proportion of rows used to run the selected stress tests
             </div>
         </div>
+        <div class="dku-btn-container--right-align settings-subsection__form_field">
+            <button class="dku-btn dku-btn-primary"
+                    type="button"
+                    ng-disabled="loading.results || !checkTestConfig().canRun"
+                    ng-click="runAnalysis()">
+                Run tests
+            </button>
+        </div>
     </form>
-    <div class="dku-btn-container--right-align">
-        <button class="dku-btn dku-btn-primary"
-                type="button"
-                ng-disabled="loading.results || !checkTestConfig().canRun"
-                ng-click="runAnalysis()">
-            Run tests
-        </button>
-    </div>
 </div>
 
 <div ng-if="loading.modelInfo" class="webapp__subsection spinner-div">
@@ -37,7 +37,8 @@
         </label>
         <help-icon help-text="Modifies the target distribution by resampling"></help-icon>
     </div>
-    <form name="forms.PRIOR_SHIFT" class="settings-subsection__form" ng-show="tests.perturbations.PRIOR_SHIFT.$activated">
+    <form name="forms.PRIOR_SHIFT" class="settings-subsection__form"
+          ng-show="tests.perturbations.PRIOR_SHIFT.$activated" ng-submit="runAnalysis()">
         <div custom-dropdown
              form="forms.PRIOR_SHIFT"
              possible-values="modelInfo.targetClasses"
@@ -66,7 +67,8 @@
         </label>
         <help-icon help-text="Randomly inserts missing values"></help-icon>
     </div>
-    <form name="forms.MISSING_VALUES" class="settings-subsection__form" ng-show="tests.perturbations.MISSING_VALUES.$activated">
+    <form name="forms.MISSING_VALUES" class="settings-subsection__form"
+          ng-show="tests.perturbations.MISSING_VALUES.$activated" ng-submit="runAnalysis()">
         <div custom-dropdown
              form="forms.MISSING_VALUES"
              possible-values="tests.perturbations.MISSING_VALUES.availableColumns"
@@ -96,7 +98,8 @@
         </label>
         <help-icon help-text="Changes the order of magnitude of each feature by some random scaling"></help-icon>
     </div>
-    <form name="forms.SCALING" class="settings-subsection__form" ng-show="tests.perturbations.SCALING.$activated">
+    <form name="forms.SCALING" class="settings-subsection__form"
+          ng-show="tests.perturbations.SCALING.$activated" ng-submit="runAnalysis()">
         <div custom-dropdown
              form="forms.SCALING"
              possible-values="tests.perturbations.SCALING.availableColumns"

--- a/webapps/stress-test-center-view/app.js
+++ b/webapps/stress-test-center-view/app.js
@@ -30,7 +30,7 @@ const versionId = webAppConfig['versionId'];
                     selected_features: new Set()
                 }
             },
-            samples: 100
+            samples: 1
         };
         $scope.modelInfo = {};
 

--- a/webapps/stress-test-center-view/backend.py
+++ b/webapps/stress-test-center-view/backend.py
@@ -50,7 +50,7 @@ def get_model_info():
 def set_stress_tests_config():
     try:
         config = json.loads(request.data)
-        stressor.set_config(config["perturbations"])
+        stressor.set_config(config)
         return {"result": "ok"}
     except:
         logger.error(traceback.format_exc())


### PR DESCRIPTION
[ch71771]

The issue described in the card should not be reproducible anymore

This PR:
- Use the input `tests.samples` field to decide the proportion of samples used by the different selected stress tests 7a0f77e 
- Change the frontend field to be a ratio ((0; 1]) instead of a percentage ((0; 100]) and adapts the field description accordingly (plus some unrelated minor UX rewording) 33a82cd & 351bd67