### PR TITLE
Webapp > backend: Use one DF per test

### DIFF
--- a/python-lib/dku_stress_test_center/metrics.py
+++ b/python-lib/dku_stress_test_center/metrics.py
@@ -14,7 +14,7 @@ def worst_group_performance(metric_name: str, y_true: np.array, y_pred: np.array
         class_mask = y_true == target_class
         performance = get_performance_metric(metric_name)(y_true[class_mask], y_pred[class_mask])
         performances.append(performance)
-    return min(performances)
+    return min(performances) if greater_perf_is_better(metric_name) else max(performances)
 
 def stress_resilience(clean_y_pred: np.array, perturbed_y_pred: np.array):
     # TODO: make it work for regression as well

--- a/python-lib/dku_stress_test_center/metrics.py
+++ b/python-lib/dku_stress_test_center/metrics.py
@@ -1,0 +1,32 @@
+import numpy as np
+from sklearn.metrics import accuracy_score
+
+def get_performance_metric(metric_name: str):
+    return accuracy_score # TODO
+
+def greater_perf_is_better(metric_name: str):
+    return True # TODO
+
+def worst_group_performance(metric_name: str, y_true: np.array, y_pred: np.array):
+    performances = []
+    target_classes = np.unique(y_true)
+    for target_class in target_classes:
+        class_mask = y_true == target_class
+        performance = get_performance_metric(metric_name)(y_true[class_mask], y_pred[class_mask])
+        performances.append(performance)
+    return min(performances)
+
+def stress_resilience(clean_y_pred: np.array, perturbed_y_pred: np.array):
+    # TODO: make it work for regression as well
+    return (clean_y_pred == perturbed_y_pred).sum() / len(clean_y_pred)
+
+def performance_variation(metric_name: str, clean_y_true: np.array, clean_y_pred: np.array,
+                          perturbed_y_true: np.array, perturbed_y_pred: np.array):
+    greater_is_better = greater_perf_is_better(metric_name)
+    performance_metric = get_performance_metric(metric_name)
+
+    clean_performance_metric = performance_metric(clean_y_true, clean_y_pred)
+    stressed_performance_metric = performance_metric(perturbed_y_true, perturbed_y_pred)
+
+    delta = stressed_performance_metric - clean_performance_metric
+    return delta if greater_is_better else - delta # TODO might be trickier than this

--- a/python-lib/dku_stress_test_center/metrics.py
+++ b/python-lib/dku_stress_test_center/metrics.py
@@ -7,12 +7,13 @@ def get_performance_metric(metric_name: str):
 def greater_perf_is_better(metric_name: str):
     return True # TODO
 
-def worst_group_performance(metric_name: str, y_true: np.array, y_pred: np.array):
+def worst_group_performance(metric_name: str, y_true: np.array, y_pred: np.array,
+                            subpopulation: np.array):
     performances = []
-    target_classes = np.unique(y_true)
-    for target_class in target_classes:
-        class_mask = y_true == target_class
-        performance = get_performance_metric(metric_name)(y_true[class_mask], y_pred[class_mask])
+    subpopulation_values = np.unique(subpopulation)
+    for subpop in subpopulation_values:
+        subpop_mask = subpopulation == subpop
+        performance = get_performance_metric(metric_name)(y_true[subpop_mask], y_pred[subpop_mask])
         performances.append(performance)
     return min(performances) if greater_perf_is_better(metric_name) else max(performances)
 

--- a/python-lib/dku_stress_test_center/model_accessor.py
+++ b/python-lib/dku_stress_test_center/model_accessor.py
@@ -31,6 +31,9 @@ class ModelAccessor(object):
             return []
         return list(self.model_handler.get_target_map().keys())
 
+    def get_evaluation_metric(self):
+        return self.model_handler.get_modeling_params["metrics"]["evaluationMetric"]
+
     def get_original_test_df(self, sample_fraction, random_state):
         np.random.seed(random_state)
         try:
@@ -48,5 +51,5 @@ class ModelAccessor(object):
     def get_predictor(self):
         return self.model_handler.get_predictor()
 
-    def predict(self, df):
-        return self.get_predictor().predict(df)
+    def predict_and_concatenate(self, df):
+        return self.model_handler.predict_and_concatenate(df)

--- a/python-lib/dku_stress_test_center/model_accessor.py
+++ b/python-lib/dku_stress_test_center/model_accessor.py
@@ -51,6 +51,6 @@ class ModelAccessor(object):
     def get_predictor(self):
         return self.model_handler.get_predictor()
 
-    def predict_and_concatenate(self, df, dropna=True):
-        df_with_pred = self.model_handler.predict_and_concatenate(df).dropna(subset=[DkuStressTestCenterConstants.PREDICTION])
-        return df_with_pred.dropna(how='all') if dropna else df_with_pred
+    def predict_and_concatenate(self, df):
+        df_with_pred = self.model_handler.predict_and_concatenate(df)
+        return df_with_pred.dropna(subset=[DkuStressTestCenterConstants.PREDICTION])

--- a/python-lib/dku_stress_test_center/model_accessor.py
+++ b/python-lib/dku_stress_test_center/model_accessor.py
@@ -51,5 +51,6 @@ class ModelAccessor(object):
     def get_predictor(self):
         return self.model_handler.get_predictor()
 
-    def predict_and_concatenate(self, df):
-        return self.model_handler.predict_and_concatenate(df)
+    def predict_and_concatenate(self, df, dropna=True):
+        df_with_pred = self.model_handler.predict_and_concatenate(df).dropna(subset=[DkuStressTestCenterConstants.PREDICTION])
+        return df_with_pred.dropna(how='all') if dropna else df_with_pred

--- a/python-lib/dku_stress_test_center/model_accessor.py
+++ b/python-lib/dku_stress_test_center/model_accessor.py
@@ -16,16 +16,20 @@ class ModelAccessor(object):
         """
         if self.model_handler.get_prediction_type() in DkuStressTestCenterConstants.DKU_CLASSIFICATION_TYPE:
             return DkuStressTestCenterConstants.CLASSIFICATION_TYPE
-        elif DkuStressTestCenterConstants.REGRESSION_TYPE in self.model_handler.get_prediction_type():
+        if DkuStressTestCenterConstants.REGRESSION_TYPE in self.model_handler.get_prediction_type():
             return DkuStressTestCenterConstants.REGRESSION_TYPE
-        else:
-            return DkuStressTestCenterConstants.CLUSTERING_TYPE
+        return DkuStressTestCenterConstants.CLUSTERING_TYPE
 
     def get_target_variable(self):
         """
         Return the name of the target variable
         """
         return self.model_handler.get_target_variable()
+
+    def get_target_classes(self):
+        if self.get_prediction_type() == DkuStressTestCenterConstants.REGRESSION_TYPE:
+            return []
+        return list(self.model_handler.get_target_map().keys())
 
     def get_original_test_df(self, sample_fraction, random_state):
         np.random.seed(random_state)

--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -99,7 +99,6 @@ class StressTestGenerator(object):
 
     def set_config(self, config: dict):
         self._sampling_proportion = config["samples"]
-        self.random_state = config["randomSeed"]
         tests_config = config["perturbations"]
         self.tests = defaultdict(list)
         for test_name, test_config in tests_config.items():

--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -99,6 +99,7 @@ class StressTestGenerator(object):
 
     def set_config(self, config: dict):
         self._sampling_proportion = config["samples"]
+        self.random_state = config["randomSeed"]
         tests_config = config["perturbations"]
         self.tests = defaultdict(list)
         for test_name, test_config in tests_config.items():

--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -142,8 +142,8 @@ class StressTestGenerator(object):
         target = self.model_accessor.get_target_variable()
         true_probas_mask = pd.get_dummies(self._clean_df[target], prefix="proba", dtype=bool)
         true_class_probas = pd.DataFrame({
-            0: self._clean_df[true_probas_mask.columns].values[true_probas_mask]
-        })
+            0: self._clean_df[true_probas_mask.columns].values[true_probas_mask],
+        }, index=true_probas_mask.index)
 
         for idx, test in enumerate(self.tests[test_type]):
             perturbed_probas = test.df_with_pred[true_probas_mask.columns]

--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -11,7 +11,7 @@ class StressTest(object):
         self.shift = shift
         self.features = list_of_features
         self.perturbed_df = None
-        self.sample_perturbation = self.__class__ in DkuStressTestCenterConstants.FEATURE_PERTURBATIONS
+        self.sample_perturbation = shift.__class__ in DkuStressTestCenterConstants.FEATURE_PERTURBATIONS
         # TODO: check valid configurations
 
     @staticmethod
@@ -23,7 +23,7 @@ class StressTest(object):
         self.perturbed_df = df
 
         if self.sample_perturbation:
-            perturbed_columns = df.columns
+            perturbed_columns = self.features
         else:
             perturbed_columns = self.perturbed_df.columns != target
 

--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -2,15 +2,15 @@
 import numpy as np
 import pandas as pd
 from dku_stress_test_center.utils import DkuStressTestCenterConstants
+from dku_stress_test_center.metrics import worst_group_performance, performance_variation, stress_resilience
 from drift_dac.perturbation_shared_utils import Shift
-from sklearn.metrics import accuracy_score
 from dku_webapp import DkuWebappConstants
 
 class StressTest(object):
     def __init__(self, shift: Shift, list_of_features: list = None):
         self.shift = shift
         self.features = list_of_features
-        self.perturbed_df = None
+        self.df_with_pred = None
         self.sample_perturbation = shift.__class__ in DkuStressTestCenterConstants.FEATURE_PERTURBATIONS
         # TODO: check valid configurations
 
@@ -19,63 +19,50 @@ class StressTest(object):
         shift = DkuStressTestCenterConstants.TESTS[shift_type](**shift_params)
         return StressTest(shift, shift_features)
 
-    def fit_transform(self, df: pd.DataFrame, target: str):
-        self.perturbed_df = df
-
+    def perturb(self, df: pd.DataFrame, target: str):
         if self.sample_perturbation:
             perturbed_columns = self.features
         else:
-            perturbed_columns = self.perturbed_df.columns != target
+            perturbed_columns = df.columns != target
 
-        xt = self.perturbed_df.loc[:, perturbed_columns].values
-        yt = self.perturbed_df[target].values
-        (xt, yt) = self.shift.transform(xt, yt)
+        xt = df.loc[:, perturbed_columns].values
+        yt = df[target].values
+        xt, yt = self.shift.transform(xt, yt)
 
-        self.perturbed_df.loc[:, perturbed_columns] = xt
-        self.perturbed_df.loc[:, target] = yt
+        df.loc[:, perturbed_columns] = xt
+        df.loc[:, target] = yt
+
+        return df
+
+    def compute_metrics(self, clean_df: pd.DataFrame, target: str, perf_metric: str):
+        clean_y_true = clean_df[target]
+        clean_y_pred = clean_df[DkuWebappConstants.PREDICTION]
+        perturbed_y_true = self.df_with_pred[target]
+        perturbed_y_pred = self.df_with_pred[DkuWebappConstants.PREDICTION]
+        return {
+            "robustness": self.compute_robustness(
+                perf_metric, clean_y_true, clean_y_pred, perturbed_y_true, perturbed_y_pred
+            ),
+            "performance_variation": performance_variation(
+                perf_metric, clean_y_true, clean_y_pred, perturbed_y_true, perturbed_y_pred
+            )
+        }
+
+    def compute_robustness(self, perf_metric: str, clean_y_true: np.array, clean_y_pred: np.array,
+                           perturbed_y_true: np.array, perturbed_y_pred: np.array):
+        if self.sample_perturbation:
+            return stress_resilience(clean_y_pred, perturbed_y_pred)
+        return worst_group_performance(perf_metric, perturbed_y_true, perturbed_y_pred)
 
 
 class StressTestGenerator(object):
     def __init__(self, random_state=65537):
+        self._random_state = random_state
+
         self.tests = None
         self.model_accessor = None
-
-        self._random_state = random_state
         self._sampling_proportion = None
-
-    def performance_metric(self, y_true: np.array, y_pred: np.array):
-        return accuracy_score(y_true, y_pred) # TODO
-
-    def performance_variation(self, clean_y_true: np.array, clean_y_pred: np.array,
-                              perturbed_y_true: np.array, perturbed_y_pred: np.array):
-        clean_performance_metric = self.performance_metric(clean_y_true, clean_y_pred)
-        stressed_performance_metric = self.performance_metric(perturbed_y_true, perturbed_y_pred)
-        return clean_performance_metric - stressed_performance_metric # TODO
-
-    def worst_group_performance(self, perturbed_y_true: np.array, perturbed_y_pred: np.array):
-        target_classes = self.model_accessor.get_target_classes()
-        performances = []
-        for target_class in target_classes:
-            class_mask = perturbed_y_true == target_class
-            performances.append(self.performance_metric(perturbed_y_true[class_mask], perturbed_y_pred[class_mask]))
-        return min(performances)
-
-    def stress_resilience(self, clean_y_pred: np.array, perturbed_y_pred: np.array):
-        # TODO: make it work for regression as well
-        return (clean_y_pred == perturbed_y_pred).sum() / len(clean_y_pred)
-
-    def compute_metrics(self, test: StressTest, clean_y_true: np.array, clean_y_pred: np.array,
-                        perturbed_y_true: np.array, perturbed_y_pred: np.array):
-        if test.sample_perturbation:
-            robustness = self.stress_resilience(clean_y_pred, perturbed_y_pred)
-        else:
-            robustness = self.worst_group_performance(perturbed_y_true, perturbed_y_pred)
-        return {
-            "performance_variation": self.performance_variation(clean_y_true, clean_y_pred,
-                                                                perturbed_y_true,
-                                                                perturbed_y_pred),
-            "robustness": robustness
-        }
+        self._clean_df = None
 
     def set_config(self, config: dict):
         self._sampling_proportion = config["samples"]
@@ -85,34 +72,35 @@ class StressTestGenerator(object):
             params, features = shift_config["params"], shift_config.get("selected_features")
             self.tests.append(StressTest.create(shift_type, params, features))
 
-    def fit_transform(self):
+    def compute_test_metrics(self, test: StressTest):
         target = self.model_accessor.get_target_variable()
+        df = self.model_accessor.get_original_test_df(sample_fraction=self._sampling_proportion,
+                                                      random_state=self._random_state)
+        perturbed_df = test.perturb(df, target)
+        test.df_with_pred = self.model_accessor.predict_and_concatenate(perturbed_df).dropna()
+        clean_df_with_pred = self._clean_df.loc[test.df_with_pred.index, :]
 
-        for test in self.tests:
-            df = self.model_accessor.get_original_test_df(sample_fraction=self._sampling_proportion,
-                                                            random_state=self._random_state)
-            test.fit_transform(df, target)
+        return {
+            test.shift.__class__.__name__: test.compute_metrics(clean_df_with_pred, target, "auc") # TODO: use get_evaluation_metric
+        }
 
-    def build_stress_metric(self):
+    def predict_clean_df(self):
+        df = self.model_accessor.get_original_test_df(sample_fraction=self._sampling_proportion,
+                                                      random_state=self._random_state)
+        self._clean_df = self.model_accessor.predict_and_concatenate(df).dropna()
+
+    def build_stress_metrics(self):
         metrics = {
             DkuWebappConstants.SAMPLE_PERTURBATION: {"metrics": {}},
             DkuWebappConstants.SUBPOPULATION_PERTURBATION: {"metrics": {}}
         }
-        df = self.model_accessor.get_original_test_df(sample_fraction=self._sampling_proportion,
-                                                        random_state=self._random_state)
-        target = self.model_accessor.get_target_variable()
-        clean_y_true = df[target]
-        clean_y_pred = self.model_accessor.predict(df)[DkuWebappConstants.PREDICTION]
+
+        self.predict_clean_df()
+
         for test in self.tests:
-            perturbed_y_true = test.perturbed_df[target]
-            perturbed_y_pred = self.model_accessor.predict(test.perturbed_df)[DkuWebappConstants.PREDICTION]
-            test_type = DkuWebappConstants.SAMPLE_PERTURBATION if test.sample_perturbation\
-                    else DkuWebappConstants.SUBPOPULATION_PERTURBATION
-            metrics[test_type]["metrics"].update({
-                test.shift.__class__.__name__:
-                    self.compute_metrics(test, clean_y_true, clean_y_pred, perturbed_y_true,
-                                         perturbed_y_pred)
-            })
+            test_type = DkuWebappConstants.SAMPLE_PERTURBATION if test.sample_perturbation else DkuWebappConstants.SUBPOPULATION_PERTURBATION
+            metrics[test_type]["metrics"] = self.compute_test_metrics(test)
+
         return metrics
 
 

--- a/python-lib/dku_stress_test_center/utils.py
+++ b/python-lib/dku_stress_test_center/utils.py
@@ -1,40 +1,22 @@
 # -*- coding: utf-8 -*-
 from drift_dac.covariate_shift import MissingValues, Scaling, Adversarial, ReplaceWord, Typos, WordDeletion
 from drift_dac.prior_shift import KnockOut
-from drift_dac.perturbation_shared_utils import Shift
-
-
-def get_stress_test_name(shift: Shift):
-    if isinstance(shift, MissingValues):
-        return DkuStressTestCenterConstants.MISSING_VALUES
-    elif isinstance(shift, Scaling):
-        return DkuStressTestCenterConstants.SCALING
-    elif isinstance(shift, Adversarial):
-        return DkuStressTestCenterConstants.ADVERSARIAL
-    elif isinstance(shift, KnockOut):
-        return DkuStressTestCenterConstants.PRIOR_SHIFT
-    elif isinstance(shift, ReplaceWord):
-        return DkuStressTestCenterConstants.REPLACE_WORD
-    elif isinstance(shift, Typos):
-        return DkuStressTestCenterConstants.TYPOS
-    elif isinstance(shift,WordDeletion):
-        return DkuStressTestCenterConstants.WORD_DELETION
-    else:
-        raise NotImplementedError()
 
 
 class DkuStressTestCenterConstants(object):
     CLEAN = 'CLEAN'
-    MISSING_VALUES = 'MISSING_VALUES'
-    SCALING = 'SCALING'
-    ADVERSARIAL = 'ADVERSARIAL'
-    PRIOR_SHIFT = 'PRIOR_SHIFT'
-    REPLACE_WORD = 'REPLACE_WORD'
-    TYPOS = 'TYPOS'
-    WORD_DELETION = 'WORD_DELETION'
+    TESTS = {
+        MissingValues.__name__: MissingValues,
+        Scaling.__name__: Scaling,
+        Adversarial.__name__: Adversarial,
+        KnockOut.__name__: KnockOut,
+        ReplaceWord.__name__: ReplaceWord,
+        WordDeletion.__name__: WordDeletion,
+        Typos.__name__: Typos
+    }
 
-    PERTURBATION_BASED_STRESS_TYPES = [MISSING_VALUES, SCALING, ADVERSARIAL, REPLACE_WORD, TYPOS, WORD_DELETION]
-    SUBPOP_SHIFT_BASED_STRESS_TYPES = [PRIOR_SHIFT]
+    FEATURE_PERTURBATIONS = [MissingValues, Scaling, Adversarial, ReplaceWord, Typos, WordDeletion]
+    SAMPLING_PERTURBATIONS = [KnockOut]
 
     CONFIDENCE = 'confidence'
     UNCERTAINTY = 'uncertainty'

--- a/python-lib/dku_stress_test_center/utils.py
+++ b/python-lib/dku_stress_test_center/utils.py
@@ -4,8 +4,6 @@ from drift_dac.prior_shift import KnockOut
 
 
 class DkuStressTestCenterConstants(object):
-    CLEAN = 'CLEAN'
-
     FEATURE_PERTURBATION = "FEATURE_PERTURBATION"
     SUBPOPULATION_SHIFT = "SUBPOPULATION_SHIFT"
 
@@ -22,12 +20,6 @@ class DkuStressTestCenterConstants(object):
     NR_CRITICAL_SAMPLES = 5
 
     PREDICTION = 'prediction'
-    CONFIDENCE = 'confidence'
-    UNCERTAINTY = 'uncertainty'
-    ACCURACY_DROP = 'accuracy_drop'
-    ROBUSTNESS = 'robustness'
-    STRESS_TEST_TYPE = '_dku_stress_test_type'
-    DKU_ROW_ID = '_dku_row_identifier_'
 
     REGRESSION_TYPE = 'REGRESSION'
     CLASSIFICATION_TYPE = 'CLASSIFICATION'

--- a/python-lib/dku_stress_test_center/utils.py
+++ b/python-lib/dku_stress_test_center/utils.py
@@ -5,19 +5,21 @@ from drift_dac.prior_shift import KnockOut
 
 class DkuStressTestCenterConstants(object):
     CLEAN = 'CLEAN'
+
+    FEATURE_PERTURBATION = "FEATURE_PERTURBATION"
+    SUBPOPULATION_SHIFT = "SUBPOPULATION_SHIFT"
+
     TESTS = {
-        MissingValues.__name__: MissingValues,
-        Scaling.__name__: Scaling,
-        Adversarial.__name__: Adversarial,
-        KnockOut.__name__: KnockOut,
-        ReplaceWord.__name__: ReplaceWord,
-        WordDeletion.__name__: WordDeletion,
-        Typos.__name__: Typos
+        MissingValues.__name__: (MissingValues, FEATURE_PERTURBATION),
+        Scaling.__name__: (Scaling, FEATURE_PERTURBATION),
+        Adversarial.__name__: (Adversarial, FEATURE_PERTURBATION),
+        KnockOut.__name__: (KnockOut, SUBPOPULATION_SHIFT),
+        ReplaceWord.__name__: (ReplaceWord, FEATURE_PERTURBATION),
+        WordDeletion.__name__: (WordDeletion, FEATURE_PERTURBATION),
+        Typos.__name__: (Typos, FEATURE_PERTURBATION)
     }
 
-    FEATURE_PERTURBATIONS = [MissingValues, Scaling, Adversarial, ReplaceWord, Typos, WordDeletion]
-    SAMPLING_PERTURBATIONS = [KnockOut]
-
+    PREDICTION = 'prediction'
     CONFIDENCE = 'confidence'
     UNCERTAINTY = 'uncertainty'
     ACCURACY_DROP = 'accuracy_drop'

--- a/python-lib/dku_stress_test_center/utils.py
+++ b/python-lib/dku_stress_test_center/utils.py
@@ -19,6 +19,8 @@ class DkuStressTestCenterConstants(object):
         Typos.__name__: (Typos, FEATURE_PERTURBATION)
     }
 
+    NR_CRITICAL_SAMPLES = 5
+
     PREDICTION = 'prediction'
     CONFIDENCE = 'confidence'
     UNCERTAINTY = 'uncertainty'

--- a/python-lib/dku_webapp/__init__.py
+++ b/python-lib/dku_webapp/__init__.py
@@ -1,2 +1,1 @@
 from dku_webapp.utils import convert_numpy_int64_to_int, pretty_floats, safe_str
-from dku_webapp.webapp_constants import DkuWebappConstants

--- a/python-lib/dku_webapp/webapp_constants.py
+++ b/python-lib/dku_webapp/webapp_constants.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 class DkuWebappConstants(object):
-
-    NAME = 'name'
-    SIZE = 'size'
     PREDICTION = 'prediction'
-    MAX_NUM_CATEGORIES = 30
+    SUBPOPULATION_PERTURBATION = 'SUBPOPULATION_PERTURBATION'
+    SAMPLE_PERTURBATION = 'SAMPLE_PERTURBATION'

--- a/python-lib/dku_webapp/webapp_constants.py
+++ b/python-lib/dku_webapp/webapp_constants.py
@@ -1,6 +1,0 @@
-# -*- coding: utf-8 -*-
-
-class DkuWebappConstants(object):
-    PREDICTION = 'prediction'
-    SUBPOPULATION_PERTURBATION = 'SUBPOPULATION_PERTURBATION'
-    SAMPLE_PERTURBATION = 'SAMPLE_PERTURBATION'

--- a/resource/templates/results-panel.html
+++ b/resource/templates/results-panel.html
@@ -80,18 +80,18 @@
                 The critical samples are the most sensitive to perturbations. They highlight where the model predictions are highly uncertain (presenting large confidence fluctuations).
             </p>
             <div class="flex dku-grid">
-                <div ng-repeat="sample in results.FEATURE_PERTURBATION.critical_samples.samples">
+                <div ng-repeat="sample in results.FEATURE_PERTURBATION.critical_samples.features">
                     <table class="table-sample table-striped">
                         <thead>
                             <tr>
                                 <th class="top-cell--blue small-title-b">
                                     <div class="flex top-cell__row">
-                                        <div>{{ results.FEATURE_PERTURBATION.critical_samples.uncertainties[$index] }}</div>
-                                        <div>0.63</div>
+                                        <div>{{ results.FEATURE_PERTURBATION.critical_samples.uncertainties[$index] | toFixedIfNeeded: 3}}</div>
+                                        <div>{{ results.FEATURE_PERTURBATION.critical_samples.mean_true_proba[$index] | toFixedIfNeeded: 3}}</div>
                                     </div>
                                     <div class="flex top-cell__row">
-                                        <div class="text-lighter">Uncertainty score</div>
-                                        <div class="text-lighter">Probability</div>
+                                        <div class="text-lighter">Uncertainty</div>
+                                        <div class="text-lighter">True class probability</div>
                                     </div>
                                 </th>
                             </tr>

--- a/resource/templates/results-panel.html
+++ b/resource/templates/results-panel.html
@@ -37,10 +37,10 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="metric in results.SUBPOPULATION_PERTURBATION.metrics">
-                        <td class="cell text-highlight">{{ tests.perturbations[metric['attack_type']].displayName }}</td>
-                        <td class="cell text-sb">{{ metric['accuracy_drop'] * 100 | toFixedIfNeeded: 3 }}%</td>
-                        <td class="cell text-sb">{{ metric['robustness'] * 100 | toFixedIfNeeded: 3 }}%</td>
+                    <tr ng-repeat="(testName, metrics) in results.SUBPOPULATION_PERTURBATION.metrics">
+                        <td class="cell text-highlight">{{ tests.perturbations[testName].displayName }}</td>
+                        <td class="cell text-sb">{{ metrics['performance_variation'] * 100 | toFixedIfNeeded: 3 }}%</td>
+                        <td class="cell text-sb">{{ metrics['robustness'] * 100 | toFixedIfNeeded: 3 }}%</td>
                     </tr>
                 </tbody>
             </table>
@@ -64,10 +64,10 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="metric in results.SAMPLE_PERTURBATION.metrics">
-                        <td class="cell text-highlight">{{ tests.perturbations[metric['attack_type']].displayName }}</td>
-                        <td class="cell text-sb">{{ metric['accuracy_drop'] * 100 | toFixedIfNeeded: 3 }}%</td>
-                        <td class="cell text-sb">{{ metric['robustness'] * 100 | toFixedIfNeeded: 3 }}%</td>
+                    <tr ng-repeat="(testName, metrics) in results.SAMPLE_PERTURBATION.metrics">
+                        <td class="cell text-highlight">{{ tests.perturbations[testName].displayName }}</td>
+                        <td class="cell text-sb">{{ metrics['performance_variation'] * 100 | toFixedIfNeeded: 3 }}%</td>
+                        <td class="cell text-sb">{{ metrics['robustness'] * 100 | toFixedIfNeeded: 3 }}%</td>
                     </tr>
                 </tbody>
             </table>

--- a/resource/templates/results-panel.html
+++ b/resource/templates/results-panel.html
@@ -20,7 +20,7 @@
 </div>
 
 <div ng-if="results && !loading.results">
-    <div class="webapp__subsection" ng-if="results.SUBPOPULATION_PERTURBATION">
+    <div class="webapp__subsection" ng-if="results.SUBPOPULATION_SHIFT">
         <div class="grand-title-b results-subsection__header">
             Subpopulation shift perturbations
         </div>
@@ -37,7 +37,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="(testName, metrics) in results.SUBPOPULATION_PERTURBATION.metrics">
+                    <tr ng-repeat="(testName, metrics) in results.SUBPOPULATION_SHIFT.metrics">
                         <td class="cell text-highlight">{{ tests.perturbations[testName].displayName }}</td>
                         <td class="cell text-sb">{{ metrics['performance_variation'] * 100 | toFixedIfNeeded: 3 }}%</td>
                         <td class="cell text-sb">{{ metrics['robustness'] * 100 | toFixedIfNeeded: 3 }}%</td>
@@ -47,7 +47,7 @@
         </div>
     </div>
 
-    <div class="webapp__subsection" ng-if="results.SAMPLE_PERTURBATION">
+    <div class="webapp__subsection" ng-if="results.FEATURE_PERTURBATION">
         <div class="grand-title-b results-subsection__header">
             Sample perturbations
         </div>
@@ -64,7 +64,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr ng-repeat="(testName, metrics) in results.SAMPLE_PERTURBATION.metrics">
+                    <tr ng-repeat="(testName, metrics) in results.FEATURE_PERTURBATION.metrics">
                         <td class="cell text-highlight">{{ tests.perturbations[testName].displayName }}</td>
                         <td class="cell text-sb">{{ metrics['performance_variation'] * 100 | toFixedIfNeeded: 3 }}%</td>
                         <td class="cell text-sb">{{ metrics['robustness'] * 100 | toFixedIfNeeded: 3 }}%</td>
@@ -80,13 +80,13 @@
                 The critical samples are the most sensitive to perturbations. They highlight where the model predictions are highly uncertain (presenting large confidence fluctuations).
             </p>
             <div class="flex dku-grid">
-                <div ng-repeat="sample in results.SAMPLE_PERTURBATION.critical_samples.samples">
+                <div ng-repeat="sample in results.FEATURE_PERTURBATION.critical_samples.samples">
                     <table class="table-sample table-striped">
                         <thead>
                             <tr>
                                 <th class="top-cell--blue small-title-b">
                                     <div class="flex top-cell__row">
-                                        <div>{{ results.SAMPLE_PERTURBATION.critical_samples.uncertainties[$index] }}</div>
+                                        <div>{{ results.FEATURE_PERTURBATION.critical_samples.uncertainties[$index] }}</div>
                                         <div>0.63</div>
                                     </div>
                                     <div class="flex top-cell__row">

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -11,6 +11,12 @@
                 Set the proportion of rows used to run the selected stress tests
             </div>
         </div>
+        <div class="control-group settings-subsection__form_field">
+            <label for="randomSeed" class="label-text">Random seed</label>
+            <input type="number" id="randomSeed"
+                   ng-model="tests.randomSeed"
+                   placeholder="65537" step="1" required>
+        </div>
         <div class="dku-btn-container--right-align settings-subsection__form_field">
             <button class="dku-btn dku-btn-primary"
                     type="button"

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -11,12 +11,6 @@
                 Set the proportion of rows used to run the selected stress tests
             </div>
         </div>
-        <div class="control-group settings-subsection__form_field">
-            <label for="randomSeed" class="label-text">Random seed</label>
-            <input type="number" id="randomSeed"
-                   ng-model="tests.randomSeed"
-                   placeholder="65537" step="1" required>
-        </div>
         <div class="dku-btn-container--right-align settings-subsection__form_field">
             <button class="dku-btn dku-btn-primary"
                     type="button"

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -26,23 +26,23 @@
     <spinner></spinner>
 </div>
 
-<div ng-if="!loading.modelInfo && tests.perturbations.PRIOR_SHIFT" class="webapp__subsection">
+<div ng-if="!loading.modelInfo && tests.perturbations.KnockOut" class="webapp__subsection">
     <div class="flex small-title-b settings-subsection__header">
-        <label class="flex" ng-class="{'text-lighter': !tests.perturbations.PRIOR_SHIFT.$activated}">
+        <label class="flex" ng-class="{'text-lighter': !tests.perturbations.KnockOut.$activated}">
             <label class="switch">
-                <input type="checkbox" ng-model="tests.perturbations.PRIOR_SHIFT.$activated">
+                <input type="checkbox" ng-model="tests.perturbations.KnockOut.$activated">
                 <div class="slider round"></div>
             </label>
-            {{ tests.perturbations.PRIOR_SHIFT.displayName }}
+            {{ tests.perturbations.KnockOut.displayName }}
         </label>
         <help-icon help-text="Modifies the target distribution by resampling"></help-icon>
     </div>
-    <form name="forms.PRIOR_SHIFT" class="settings-subsection__form"
-          ng-show="tests.perturbations.PRIOR_SHIFT.$activated" ng-submit="runAnalysis()">
+    <form name="forms.KnockOut" class="settings-subsection__form"
+          ng-show="tests.perturbations.KnockOut.$activated" ng-submit="runAnalysis()">
         <div custom-dropdown
-             form="forms.PRIOR_SHIFT"
+             form="forms.KnockOut"
              possible-values="modelInfo.targetClasses"
-             item="tests.perturbations.PRIOR_SHIFT.params.cl"
+             item="tests.perturbations.KnockOut.params.cl"
              item-name="class"
              label="Selected class"
              class="settings-subsection__form_field">
@@ -50,29 +50,29 @@
         <div class="control-group settings-subsection__form_field">
             <label for="priorShift" class="label-text">Desired proportion of samples with selected class</label>
             <input type="number" id="priorShift"
-                   ng-model="tests.perturbations.PRIOR_SHIFT.params.samples_fraction"
+                   ng-model="tests.perturbations.KnockOut.params.samples_fraction"
                    placeholder="0.5" step="0.01" min="0" max="1" required>
         </div>
     </form>
 </div>
 
-<div ng-if="!loading.modelInfo && tests.perturbations.MISSING_VALUES" class="webapp__subsection">
+<div ng-if="!loading.modelInfo && tests.perturbations.MissingValues" class="webapp__subsection">
     <div class="flex small-title-b settings-subsection__header">
-        <label class="flex" ng-class="{'text-lighter': !tests.perturbations.MISSING_VALUES.$activated}">
+        <label class="flex" ng-class="{'text-lighter': !tests.perturbations.MissingValues.$activated}">
             <label class="switch">
-                <input type="checkbox" ng-model="tests.perturbations.MISSING_VALUES.$activated">
+                <input type="checkbox" ng-model="tests.perturbations.MissingValues.$activated">
                 <div class="slider round"></div>
             </label>
-            {{ tests.perturbations.MISSING_VALUES.displayName }}
+            {{ tests.perturbations.MissingValues.displayName }}
         </label>
         <help-icon help-text="Randomly inserts missing values"></help-icon>
     </div>
-    <form name="forms.MISSING_VALUES" class="settings-subsection__form"
-          ng-show="tests.perturbations.MISSING_VALUES.$activated" ng-submit="runAnalysis()">
+    <form name="forms.MissingValues" class="settings-subsection__form"
+          ng-show="tests.perturbations.MissingValues.$activated" ng-submit="runAnalysis()">
         <div custom-dropdown
-             form="forms.MISSING_VALUES"
-             possible-values="tests.perturbations.MISSING_VALUES.availableColumns"
-             items="tests.perturbations.MISSING_VALUES.selected_features"
+             form="forms.MissingValues"
+             possible-values="tests.perturbations.MissingValues.availableColumns"
+             items="tests.perturbations.MissingValues.selected_features"
              item-name="feature"
              item-image="featureToTypeIcon"
              label="Corrupted features"
@@ -81,29 +81,29 @@
         <div class="control-group settings-subsection__form_field">
             <label for="missingValues" class="label-text">Proportion of corrupted samples</label>
             <input type="number" id="missingValues"
-                   ng-model="tests.perturbations.MISSING_VALUES.params.samples_fraction"
+                   ng-model="tests.perturbations.MissingValues.params.samples_fraction"
                    placeholder="0.5" step="0.01" min="0.01" max="1" required>
         </div>
     </form>
 </div>
 
-<div ng-if="!loading.modelInfo && tests.perturbations.SCALING" class="webapp__subsection">
+<div ng-if="!loading.modelInfo && tests.perturbations.Scaling" class="webapp__subsection">
     <div class="flex small-title-b settings-subsection__header">
-        <label class="flex" ng-class="{'text-lighter': !tests.perturbations.SCALING.$activated}">
+        <label class="flex" ng-class="{'text-lighter': !tests.perturbations.Scaling.$activated}">
             <label class="switch">
-                <input type="checkbox" ng-model="tests.perturbations.SCALING.$activated">
+                <input type="checkbox" ng-model="tests.perturbations.Scaling.$activated">
                 <div class="slider round"></div>
             </label>
-            {{ tests.perturbations.SCALING.displayName }}
+            {{ tests.perturbations.Scaling.displayName }}
         </label>
         <help-icon help-text="Changes the order of magnitude of each feature by some random scaling"></help-icon>
     </div>
-    <form name="forms.SCALING" class="settings-subsection__form"
-          ng-show="tests.perturbations.SCALING.$activated" ng-submit="runAnalysis()">
+    <form name="forms.Scaling" class="settings-subsection__form"
+          ng-show="tests.perturbations.Scaling.$activated" ng-submit="runAnalysis()">
         <div custom-dropdown
-             form="forms.SCALING"
-             possible-values="tests.perturbations.SCALING.availableColumns"
-             items="tests.perturbations.SCALING.selected_features"
+             form="forms.Scaling"
+             possible-values="tests.perturbations.Scaling.availableColumns"
+             items="tests.perturbations.Scaling.selected_features"
              item-name="feature"
              item-image="featureToTypeIcon"
              label="Corrupted features"
@@ -112,7 +112,7 @@
         <div class="control-group settings-subsection__form_field">
             <label for="scaling" class="label-text">Proportion of corrupted samples</label>
             <input type="number" id="scaling"
-                   ng-model="tests.perturbations.SCALING.params.samples_fraction"
+                   ng-model="tests.perturbations.Scaling.params.samples_fraction"
                    placeholder="0.5" step="0.01" min="0" max="1" required>
         </div>
     </form>

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -26,23 +26,23 @@
     <spinner></spinner>
 </div>
 
-<div ng-if="!loading.modelInfo && tests.perturbations.KnockOut" class="webapp__subsection">
+<div ng-if="!loading.modelInfo && tests.perturbations.Rebalance" class="webapp__subsection">
     <div class="flex small-title-b settings-subsection__header">
-        <label class="flex" ng-class="{'text-lighter': !tests.perturbations.KnockOut.$activated}">
+        <label class="flex" ng-class="{'text-lighter': !tests.perturbations.Rebalance.$activated}">
             <label class="switch">
-                <input type="checkbox" ng-model="tests.perturbations.KnockOut.$activated">
+                <input type="checkbox" ng-model="tests.perturbations.Rebalance.$activated">
                 <div class="slider round"></div>
             </label>
-            {{ tests.perturbations.KnockOut.displayName }}
+            {{ tests.perturbations.Rebalance.displayName }}
         </label>
         <help-icon help-text="Modifies the target distribution by resampling"></help-icon>
     </div>
-    <form name="forms.KnockOut" class="settings-subsection__form"
-          ng-show="tests.perturbations.KnockOut.$activated" ng-submit="runAnalysis()">
+    <form name="forms.Rebalance" class="settings-subsection__form"
+          ng-show="tests.perturbations.Rebalance.$activated" ng-submit="runAnalysis()">
         <div custom-dropdown
-             form="forms.KnockOut"
+             form="forms.Rebalance"
              possible-values="modelInfo.targetClasses"
-             item="tests.perturbations.KnockOut.params.cl"
+             item="tests.perturbations.Rebalance.params.cl"
              item-name="class"
              label="Selected class"
              class="settings-subsection__form_field">
@@ -50,7 +50,7 @@
         <div class="control-group settings-subsection__form_field">
             <label for="priorShift" class="label-text">Desired proportion of samples with selected class</label>
             <input type="number" id="priorShift"
-                   ng-model="tests.perturbations.KnockOut.params.samples_fraction"
+                   ng-model="tests.perturbations.Rebalance.params.samples_fraction"
                    placeholder="0.5" step="0.01" min="0" max="1" required>
         </div>
     </form>

--- a/webapps/stress-test-center-view/app.js
+++ b/webapps/stress-test-center-view/app.js
@@ -35,7 +35,8 @@ const versionId = webAppConfig['versionId'];
                     selected_features: new Set()
                 }
             },
-            samples: 1
+            samples: 1,
+            randomSeed: 65537
         };
         $scope.modelInfo = {};
 
@@ -68,7 +69,8 @@ const versionId = webAppConfig['versionId'];
         $scope.runAnalysis = function () {
             const { canRun, config } = $scope.checkTestConfig();
             if (!canRun) return;
-            const perturbationsConfig = config.reduce(function(fullParams, currentEntry) {
+            const requestParams = Object.assign({}, $scope.tests);
+            requestParams.perturbations = config.reduce(function(fullParams, currentEntry) {
                 const [testName, testSettings] = currentEntry;
                 fullParams[testName] = {
                     params: testSettings.params
@@ -81,9 +83,7 @@ const versionId = webAppConfig['versionId'];
 
             $scope.loading.results = true;
             $http.post(
-                getWebAppBackendUrl("stress-tests-config"),
-                { perturbations: perturbationsConfig, samples: $scope.tests.samples}
-            ).then(function() {
+                getWebAppBackendUrl("stress-tests-config"), requestParams).then(function() {
                 $http.get(getWebAppBackendUrl("compute"))
                     .then(function(response) {
                         $scope.loading.results = false;

--- a/webapps/stress-test-center-view/app.js
+++ b/webapps/stress-test-center-view/app.js
@@ -17,7 +17,7 @@ const versionId = webAppConfig['versionId'];
         $scope.forms = {};
         $scope.tests = {
             perturbations: {
-                KnockOut: {
+                Rebalance: {
                     displayName: "Target distribution",
                     needsTargetClasses: true,
                     params: { samples_fraction: .5 }

--- a/webapps/stress-test-center-view/app.js
+++ b/webapps/stress-test-center-view/app.js
@@ -17,18 +17,18 @@ const versionId = webAppConfig['versionId'];
         $scope.forms = {};
         $scope.tests = {
             perturbations: {
-                PRIOR_SHIFT: {
+                KnockOut: {
                     displayName: "Target distribution",
                     needsTargetClasses: true,
                     params: { samples_fraction: .5 }
                 },
-                MISSING_VALUES: {
+                MissingValues: {
                     displayName: "Missing values",
                     allowedFeatureTypes: ["NUMERIC", "CATEGORY"],
                     params: { samples_fraction: .5 },
                     selected_features: new Set()
                 },
-                SCALING: {
+                Scaling: {
                     displayName: "Scaling",
                     allowedFeatureTypes: ["NUMERIC"],
                     params: { samples_fraction: .5 },

--- a/webapps/stress-test-center-view/app.js
+++ b/webapps/stress-test-center-view/app.js
@@ -35,8 +35,7 @@ const versionId = webAppConfig['versionId'];
                     selected_features: new Set()
                 }
             },
-            samples: 1,
-            randomSeed: 65537
+            samples: 1
         };
         $scope.modelInfo = {};
 
@@ -69,8 +68,7 @@ const versionId = webAppConfig['versionId'];
         $scope.runAnalysis = function () {
             const { canRun, config } = $scope.checkTestConfig();
             if (!canRun) return;
-            const requestParams = Object.assign({}, $scope.tests);
-            requestParams.perturbations = config.reduce(function(fullParams, currentEntry) {
+            const perturbationsConfig = config.reduce(function(fullParams, currentEntry) {
                 const [testName, testSettings] = currentEntry;
                 fullParams[testName] = {
                     params: testSettings.params
@@ -83,7 +81,9 @@ const versionId = webAppConfig['versionId'];
 
             $scope.loading.results = true;
             $http.post(
-                getWebAppBackendUrl("stress-tests-config"), requestParams).then(function() {
+                getWebAppBackendUrl("stress-tests-config"),
+                { perturbations: perturbationsConfig, samples: $scope.tests.samples}
+            ).then(function() {
                 $http.get(getWebAppBackendUrl("compute"))
                     .then(function(response) {
                         $scope.loading.results = false;

--- a/webapps/stress-test-center-view/backend.py
+++ b/webapps/stress-test-center-view/backend.py
@@ -6,14 +6,13 @@ import traceback
 from flask import request, jsonify
 import json
 
-from dataiku import Model, api_client
+from dataiku import Model
 from dataiku.customwebapp import get_webapp_config
 from dataiku.doctor.posttraining.model_information_handler import PredictionModelInformationHandler
 
 from dku_stress_test_center.model_accessor import ModelAccessor
 from dku_stress_test_center.stress_test_center import StressTestGenerator
-from dku_stress_test_center.stress_test_center import build_stress_metric, get_critical_samples
-from dku_stress_test_center.stress_test_center import DkuStressTestCenterConstants
+from dku_stress_test_center.stress_test_center import get_critical_samples
 from model_metadata import get_model_handler
 from dku_webapp import convert_numpy_int64_to_int, pretty_floats
 
@@ -32,10 +31,9 @@ def get_model_info():
             original_model_handler = get_model_handler(model, version_id)
         else:
             original_model_handler = PredictionModelInformationHandler.from_full_model_id(fmi)
-        is_regression = 'REGRESSION' in original_model_handler.get_prediction_type()
         stressor.model_accessor = ModelAccessor(original_model_handler)
         return jsonify(
-            target_classes=[] if is_regression else list(original_model_handler.get_target_map().keys()),
+            target_classes=stressor.model_accessor.get_target_classes(),
             features={
                 feature: preprocessing["type"]
                 for (feature, preprocessing) in stressor.model_accessor.get_per_feature().items()
@@ -61,56 +59,30 @@ def compute():
     try:
         # Get test data
         model_accessor = stressor.model_accessor
-
-        reversed_target_mapping = {v: k for k, v in model_accessor.model_handler.get_target_map().items()}
-        pos_label = reversed_target_mapping.get(1)
-
-        # perturbed_df is a dataset of schema feat_1 | feat_2 | ... | _STRESS_TEST_TYPE | _DKU_ID_
-        perturbed_df = stressor.fit_transform()
-        perturbed_df_with_prediction = model_accessor.predict(perturbed_df)
-
+        stressor.fit_transform()
 
         # Compute the performance drop metrics
         target = model_accessor.get_target_variable()
-        metrics_df = build_stress_metric(y_true=perturbed_df[target],
-                                         y_pred=perturbed_df_with_prediction['prediction'],
-                                         stress_test_indicator=perturbed_df[DkuStressTestCenterConstants.STRESS_TEST_TYPE],
-                                         pos_label=pos_label).rename(columns={DkuStressTestCenterConstants.STRESS_TEST_TYPE: "attack_type"})
-        metrics_df_sample_perturbations = metrics_df[metrics_df["attack_type"].isin(DkuStressTestCenterConstants.PERTURBATION_BASED_STRESS_TYPES)]
-        metrics_df_subpop_perturbations = metrics_df[metrics_df["attack_type"].isin(DkuStressTestCenterConstants.SUBPOP_SHIFT_BASED_STRESS_TYPES)]
-
+        results = stressor.build_stress_metric()
+ 
         # Compute the critical samples
-        y_true = perturbed_df[target]
+        #y_true = perturbed_df[target]
 
-        original_target_value = list(model_accessor.model_handler.get_target_map().keys())
-        y_true_class_confidence = perturbed_df_with_prediction[
-            ['proba_{}'.format(original_target_value[0]), 'proba_{}'.format(original_target_value[1])]
-        ].values
-        y_true_idx = np.array([
-            [True, False] if y == reversed_target_mapping.get(1) else [False, True] for y in y_true
-        ])
-        y_true_class_confidence = y_true_class_confidence[y_true_idx]
+        #original_target_value = list(model_accessor.model_handler.get_target_map().keys())
+        #y_true_class_confidence = perturbed_df_with_prediction[
+        #    ['proba_{}'.format(original_target_value[0]), 'proba_{}'.format(original_target_value[1])]
+        #].values
+        #y_true_idx = np.array([
+        #    [True, False] if y == reversed_target_mapping.get(1) else [False, True] for y in y_true
+        #])
+        #y_true_class_confidence = y_true_class_confidence[y_true_idx]
 
-        critical_samples_df, uncertainties = get_critical_samples(
-            y_true_class_confidence=y_true_class_confidence,
-            perturbed_df=perturbed_df
-        )
+        #critical_samples_df, uncertainties = get_critical_samples(
+        #    y_true_class_confidence=y_true_class_confidence,
+        #    perturbed_df=perturbed_df
+        #)
 
-        data = {}
-        if not metrics_df_sample_perturbations.empty:
-            data['SAMPLE_PERTURBATION'] = {
-                'metrics': metrics_df_sample_perturbations.to_dict('records'),
-                'critical_samples': {
-                    'samples': critical_samples_df.to_dict('records'),
-                    'uncertainties': uncertainties
-                }
-            }
-
-        if not metrics_df_subpop_perturbations.empty:
-            data['SUBPOPULATION_PERTURBATION'] = {
-                'metrics': metrics_df_subpop_perturbations.to_dict('records'),
-            }
-        return simplejson.dumps(pretty_floats(data), ignore_nan=True, default=convert_numpy_int64_to_int)
+        return simplejson.dumps(pretty_floats(results), ignore_nan=True, default=convert_numpy_int64_to_int)
     except:
         logger.error("When trying to call compute endpoint: {}.".format(traceback.format_exc()))
         return "{}. Check backend log for more details.".format(traceback.format_exc()), 500

--- a/webapps/stress-test-center-view/backend.py
+++ b/webapps/stress-test-center-view/backend.py
@@ -59,11 +59,9 @@ def compute():
     try:
         # Get test data
         model_accessor = stressor.model_accessor
-        stressor.fit_transform()
 
         # Compute the performance drop metrics
-        target = model_accessor.get_target_variable()
-        results = stressor.build_stress_metric()
+        results = stressor.build_stress_metrics()
  
         # Compute the critical samples
         #y_true = perturbed_df[target]

--- a/webapps/stress-test-center-view/backend.py
+++ b/webapps/stress-test-center-view/backend.py
@@ -57,9 +57,6 @@ def set_stress_tests_config():
 @app.route('/compute', methods=["GET"])
 def compute():
     try:
-        # Get test data
-        model_accessor = stressor.model_accessor
-
         # Compute the performance drop metrics
         results = stressor.build_stress_metrics()
  

--- a/webapps/stress-test-center-view/backend.py
+++ b/webapps/stress-test-center-view/backend.py
@@ -7,12 +7,12 @@ from flask import request, jsonify
 import json
 
 from dataiku import Model
+from dku_stress_test_center.utils import DkuStressTestCenterConstants
 from dataiku.customwebapp import get_webapp_config
 from dataiku.doctor.posttraining.model_information_handler import PredictionModelInformationHandler
 
 from dku_stress_test_center.model_accessor import ModelAccessor
 from dku_stress_test_center.stress_test_center import StressTestGenerator
-from dku_stress_test_center.stress_test_center import get_critical_samples
 from model_metadata import get_model_handler
 from dku_webapp import convert_numpy_int64_to_int, pretty_floats
 
@@ -64,21 +64,12 @@ def compute():
         results = stressor.build_stress_metrics()
  
         # Compute the critical samples
-        #y_true = perturbed_df[target]
-
-        #original_target_value = list(model_accessor.model_handler.get_target_map().keys())
-        #y_true_class_confidence = perturbed_df_with_prediction[
-        #    ['proba_{}'.format(original_target_value[0]), 'proba_{}'.format(original_target_value[1])]
-        #].values
-        #y_true_idx = np.array([
-        #    [True, False] if y == reversed_target_mapping.get(1) else [False, True] for y in y_true
-        #])
-        #y_true_class_confidence = y_true_class_confidence[y_true_idx]
-
-        #critical_samples_df, uncertainties = get_critical_samples(
-        #    y_true_class_confidence=y_true_class_confidence,
-        #    perturbed_df=perturbed_df
-        #)
+        if DkuStressTestCenterConstants.FEATURE_PERTURBATION in results:
+            results[DkuStressTestCenterConstants.FEATURE_PERTURBATION].update(
+                critical_samples=stressor.get_critical_samples(
+                    DkuStressTestCenterConstants.FEATURE_PERTURBATION
+                )
+            )
 
         return simplejson.dumps(pretty_floats(results), ignore_nan=True, default=convert_numpy_int64_to_int)
     except:


### PR DESCRIPTION
- Great refacto ( [ch74714] )
  - Do not use one df for all the tests
  - Use subclasses for stress tests depending on their type (subpop shift vs feature perturbations)
- Move metrics computation into a dedicated file `metrics.py` (to prepare for the time where the metric used during training will be used instead of hardcoded AUC)
- Remove webapp constants (only one file with constants)
- Probability displayed for the critical samples is now the proper one ( [ch66633] ) 