### PR TITLE
Webapp > target distribution test: Allow to set a multiclass distribution

### DIFF
--- a/python-lib/dku_stress_test_center/utils.py
+++ b/python-lib/dku_stress_test_center/utils.py
@@ -22,7 +22,7 @@ class DkuStressTestCenterConstants(object):
         ),
         Adversarial.__name__: (Adversarial, FEATURE_PERTURBATION),
         Rebalance.__name__: (
-            lambda **params: Rebalance({params["cl"]: params["samples_fraction"]}),
+            lambda **params: Rebalance(**params),
             SUBPOPULATION_SHIFT
         ),
         ReplaceWord.__name__: (ReplaceWord, FEATURE_PERTURBATION),

--- a/resource/js/helpers.js
+++ b/resource/js/helpers.js
@@ -116,19 +116,20 @@ app.directive("customDropdown", function() {
         templateUrl:'/plugins/stress-test-center/resource/templates/custom-dropdown.html',
         link: function(scope, elem, attrs) {
             const isMulti = !!attrs.items;
+            scope.validity = scope.validity || "dropdown-not-empty";
             scope.form.$setValidity(scope.validity, false);
 
             scope.canBeSelected = function(item) {
                 if (!scope.notAvailableValues) return true;
                 return item === scope.item || !(item in scope.notAvailableValues);
-            }
+            };
 
             scope.isSelected = function(value) {
                 if (isMulti) {
                     return scope.items.has(value);
                 }
                 return scope.item === value;
-            }
+            };
 
             scope.updateSelection = function(value, event) {
                 if (isMulti) {
@@ -146,7 +147,7 @@ app.directive("customDropdown", function() {
                     scope.item = value;
                 }
                 scope.form.$setValidity(scope.validity, !!scope.item || !!(scope.items || {}).size);
-            }
+            };
 
             scope.getPlaceholder = function() {
                 if (isMulti) {
@@ -155,11 +156,11 @@ app.directive("customDropdown", function() {
                 }
                 if (!scope.item) return "Select a " + scope.itemName;
                 return scope.item;
-            }
+            };
 
             scope.toggleDropdown = function() {
                 scope.isOpen = !scope.isOpen;
-            }
+            };
 
             const dropdownElem = elem.find(".custom-dropdown");
             const labelElem = elem.find(".label-text");
@@ -167,7 +168,7 @@ app.directive("customDropdown", function() {
                 if ((target) && ( angular.element(target).closest(dropdownElem)[0]
                     || angular.element(target).closest(labelElem)[0] )) { return; }
                 scope.isOpen = false;
-            })
+            });
         }
     }
 })
@@ -202,18 +203,18 @@ app.directive("keyValueList", function($timeout) {
                     VALIDITY,
                     !!scope.keys.length && scope.keys.every(key => !!key)
                 );
-            }
+            };
 
             scope.canAddListItem = function() {
                 return scope.keys.length < scope.keyOptions.length;
-            }
+            };
 
             scope.addListItem = function() {
                 if (!scope.keys.length) {
                     scope.form.$setValidity(VALIDITY, true);
                 }
                 scope.keys.push(null);
-            }
+            };
 
             scope.dropdownChange = function(oldValue, newValue, keyElem) {
                 scope.map[newValue] = scope.map[oldValue] || DEFAULT_VALUE;
@@ -246,7 +247,7 @@ app.directive("helpIcon", function () {
                 const tooltip = elem.find(".help-text__tooltip");
                 tooltip.css("top", (top - 8) + "px");
                 tooltip.toggleClass("tooltip--hidden");
-            }
+            };
         }
     }
 });

--- a/resource/js/helpers.js
+++ b/resource/js/helpers.js
@@ -108,7 +108,7 @@ app.directive("customDropdown", function() {
             item: '=',
             items: '=',
             possibleValues: '=',
-            taboo: '=',
+            notAvailableValues: '=',
             validity: '@',
             onChange: '='
         },
@@ -119,8 +119,8 @@ app.directive("customDropdown", function() {
             scope.form.$setValidity(scope.validity, false);
 
             scope.canBeSelected = function(item) {
-                if (!scope.taboo) return true;
-                return item === scope.item || !(item in scope.taboo);
+                if (!scope.notAvailableValues) return true;
+                return item === scope.item || !(item in scope.notAvailableValues);
             }
 
             scope.isSelected = function(value) {

--- a/resource/js/helpers.js
+++ b/resource/js/helpers.js
@@ -173,6 +173,8 @@ app.directive("customDropdown", function() {
     }
 })
 
+// For now, key can only be one of a preset of values (dropdown)
+// & the value field only accepts numbers
 app.directive("keyValueList", function() {
     return {
         scope: {
@@ -181,12 +183,14 @@ app.directive("keyValueList", function() {
             keyLabel: '@',
             keyItemLabel: '@',
             valueLabel: '@',
+            valueRange: '@',
             form: "="
         },
         restrict: 'A',
         templateUrl:'/plugins/stress-test-center/resource/templates/key-value-list.html',
         link: function(scope) {
             scope.keys = [null];
+            [ scope.valueMin, scope.valueMax ] = scope.$eval(scope.valueRange) || [null, null];
             scope.form.$setValidity("key-value-list-valid", false);
 
             scope.deleteListItem = function(index) {

--- a/resource/js/helpers.js
+++ b/resource/js/helpers.js
@@ -110,12 +110,11 @@ app.directive("customDropdown", function() {
             possibleValues: '=',
             taboo: '=',
             validity: '@',
-            index: '='
+            onChange: '='
         },
         restrict: 'A',
         templateUrl:'/plugins/stress-test-center/resource/templates/custom-dropdown.html',
         link: function(scope, elem, attrs) {
-            const isInList = !!attrs.index; // TODO: tight coupling
             const isMulti = !!attrs.items;
             scope.form.$setValidity(scope.validity, false);
 
@@ -141,8 +140,8 @@ app.directive("customDropdown", function() {
                     event.stopPropagation();
                 } else {
                     if (scope.item === value) return;
-                    if (isInList) {
-                        scope.$emit("dropdownChange", scope.item, value, scope.index, elem);
+                    if (scope.onChange) {
+                        scope.onChange(scope.item, value, elem);
                     }
                     scope.item = value;
                 }
@@ -212,15 +211,14 @@ app.directive("keyValueList", function($timeout) {
                 scope.keys.push(null);
             }
 
-            scope.$on("dropdownChange", function(e, oldVal, newVal, idx, keyElem) {
-                scope.keys[idx] = newVal;
-                scope.map[newVal] = scope.map[oldVal] || DEFAULT_VALUE;
-                delete scope.map[oldVal];
+            scope.dropdownChange = function(oldValue, newValue, keyElem) {
+                scope.map[newValue] = scope.map[oldValue] || DEFAULT_VALUE;
+                delete scope.map[oldValue];
                 $timeout(function() {
                     const valueElem = keyElem.parent().find(".key-value-element__value")[0];
                     valueElem.focus();
                 });
-            });
+            };
         }
     }
 });

--- a/resource/js/helpers.js
+++ b/resource/js/helpers.js
@@ -184,15 +184,17 @@ app.directive("keyValueList", function($timeout) {
             keyItemLabel: '@',
             valueLabel: '@',
             valueRange: '@',
-            form: "="
+            step: '=',
+            defaultValue: '=',
+            form: '='
         },
         restrict: 'A',
         templateUrl:'/plugins/stress-test-center/resource/templates/key-value-list.html',
         link: function(scope) {
             scope.keys = [null];
+            scope.step = scope.step || "any";
             [ scope.valueMin, scope.valueMax ] = scope.$eval(scope.valueRange) || [null, null];
             const VALIDITY = "key-value-list-valid";
-            const DEFAULT_VALUE = .5;
             scope.form.$setValidity(VALIDITY, false);
 
             scope.deleteListItem = function(index) {
@@ -217,7 +219,7 @@ app.directive("keyValueList", function($timeout) {
             };
 
             scope.dropdownChange = function(oldValue, newValue, keyElem) {
-                scope.map[newValue] = scope.map[oldValue] || DEFAULT_VALUE;
+                scope.map[newValue] = scope.map[oldValue] || scope.defaultValue;
                 delete scope.map[oldValue];
                 $timeout(function() {
                     const valueElem = keyElem.parent().find(".key-value-element__value")[0];

--- a/resource/js/helpers.js
+++ b/resource/js/helpers.js
@@ -140,6 +140,7 @@ app.directive("customDropdown", function() {
                     }
                     event.stopPropagation();
                 } else {
+                    if (scope.item === value) return;
                     if (isInList) {
                         scope.$emit("dropdownChange", scope.item, value, scope.index);
                     }
@@ -185,10 +186,11 @@ app.directive("keyValueList", function() {
         restrict: 'A',
         templateUrl:'/plugins/stress-test-center/resource/templates/key-value-list.html',
         link: function(scope) {
-            scope.keys = [];
+            scope.keys = [null];
             scope.form.$setValidity("key-value-list-valid", false);
 
             scope.deleteListItem = function(index) {
+                if (!index) return;
                 const removedKey = scope.keys.splice(index, 1)[0];
                 delete scope.map[removedKey];
                 scope.form.$setValidity(

--- a/resource/js/helpers.js
+++ b/resource/js/helpers.js
@@ -204,6 +204,10 @@ app.directive("keyValueList", function($timeout) {
                 );
             }
 
+            scope.canAddListItem = function() {
+                return scope.keys.length < scope.keyOptions.length;
+            }
+
             scope.addListItem = function() {
                 if (!scope.keys.length) {
                     scope.form.$setValidity(VALIDITY, true);

--- a/resource/js/helpers.js
+++ b/resource/js/helpers.js
@@ -108,18 +108,18 @@ app.directive("customDropdown", function() {
             item: '=',
             items: '=',
             possibleValues: '=',
-            taboo: "=",
-            index: "="
+            taboo: '=',
+            validity: '@',
+            index: '='
         },
         restrict: 'A',
         templateUrl:'/plugins/stress-test-center/resource/templates/custom-dropdown.html',
         link: function(scope, elem, attrs) {
             const isInList = !!attrs.index; // TODO: tight coupling
             const isMulti = !!attrs.items;
-            const validity = isInList ? "key-value-list-valid" : "dropdown-not-empty";
-            scope.form.$setValidity(validity, false);
+            scope.form.$setValidity(scope.validity, false);
 
-            scope.notInTaboo = function(item) {
+            scope.canBeSelected = function(item) {
                 if (!scope.taboo) return true;
                 return item === scope.item || !(item in scope.taboo);
             }
@@ -146,7 +146,7 @@ app.directive("customDropdown", function() {
                     }
                     scope.item = value;
                 }
-                scope.form.$setValidity(validity, !!scope.item || !!(scope.items || {}).size);
+                scope.form.$setValidity(scope.validity, !!scope.item || !!(scope.items || {}).size);
             }
 
             scope.getPlaceholder = function() {
@@ -191,21 +191,22 @@ app.directive("keyValueList", function($timeout) {
         link: function(scope) {
             scope.keys = [null];
             [ scope.valueMin, scope.valueMax ] = scope.$eval(scope.valueRange) || [null, null];
-            scope.form.$setValidity("key-value-list-valid", false);
+            const validity = "key-value-list-valid";
+            scope.form.$setValidity(validity, false);
 
             scope.deleteListItem = function(index) {
                 if (!index) return;
                 const removedKey = scope.keys.splice(index, 1)[0];
                 delete scope.map[removedKey];
                 scope.form.$setValidity(
-                    "key-value-list-valid",
+                    validity,
                     !!scope.keys.length && scope.keys.every(key => !!key)
                 );
             }
 
             scope.addListItem = function() {
                 if (!scope.keys.length) {
-                    scope.form.$setValidity("key-value-list-valid", true);
+                    scope.form.$setValidity(validity, true);
                 }
                 scope.keys.push(null);
             }

--- a/resource/js/helpers.js
+++ b/resource/js/helpers.js
@@ -191,29 +191,30 @@ app.directive("keyValueList", function($timeout) {
         link: function(scope) {
             scope.keys = [null];
             [ scope.valueMin, scope.valueMax ] = scope.$eval(scope.valueRange) || [null, null];
-            const validity = "key-value-list-valid";
-            scope.form.$setValidity(validity, false);
+            const VALIDITY = "key-value-list-valid";
+            const DEFAULT_VALUE = .5;
+            scope.form.$setValidity(VALIDITY, false);
 
             scope.deleteListItem = function(index) {
                 if (!index) return;
                 const removedKey = scope.keys.splice(index, 1)[0];
                 delete scope.map[removedKey];
                 scope.form.$setValidity(
-                    validity,
+                    VALIDITY,
                     !!scope.keys.length && scope.keys.every(key => !!key)
                 );
             }
 
             scope.addListItem = function() {
                 if (!scope.keys.length) {
-                    scope.form.$setValidity(validity, true);
+                    scope.form.$setValidity(VALIDITY, true);
                 }
                 scope.keys.push(null);
             }
 
             scope.$on("dropdownChange", function(e, oldVal, newVal, idx, keyElem) {
                 scope.keys[idx] = newVal;
-                scope.map[newVal] = scope.map[oldVal];
+                scope.map[newVal] = scope.map[oldVal] || DEFAULT_VALUE;
                 delete scope.map[oldVal];
                 $timeout(function() {
                     const valueElem = keyElem.parent().find(".key-value-element__value")[0];

--- a/resource/js/helpers.js
+++ b/resource/js/helpers.js
@@ -142,7 +142,7 @@ app.directive("customDropdown", function() {
                 } else {
                     if (scope.item === value) return;
                     if (isInList) {
-                        scope.$emit("dropdownChange", scope.item, value, scope.index);
+                        scope.$emit("dropdownChange", scope.item, value, scope.index, elem);
                     }
                     scope.item = value;
                 }
@@ -175,7 +175,7 @@ app.directive("customDropdown", function() {
 
 // For now, key can only be one of a preset of values (dropdown)
 // & the value field only accepts numbers
-app.directive("keyValueList", function() {
+app.directive("keyValueList", function($timeout) {
     return {
         scope: {
             keyOptions: '=',
@@ -210,10 +210,14 @@ app.directive("keyValueList", function() {
                 scope.keys.push(null);
             }
 
-            scope.$on("dropdownChange", function(e, oldVal, newVal, idx) {
+            scope.$on("dropdownChange", function(e, oldVal, newVal, idx, keyElem) {
                 scope.keys[idx] = newVal;
                 scope.map[newVal] = scope.map[oldVal];
                 delete scope.map[oldVal];
+                $timeout(function() {
+                    const valueElem = keyElem.parent().find(".key-value-element__value")[0];
+                    valueElem.focus();
+                });
             });
         }
     }

--- a/resource/templates/custom-dropdown.html
+++ b/resource/templates/custom-dropdown.html
@@ -10,7 +10,7 @@
         <div class="custom-dropdown__body" ng-if="isOpen">
             <div class="custom-dropdown-row"
                 ng-click="updateSelection(item, $event)"
-                ng-repeat="item in possibleValues">
+                ng-repeat="item in possibleValues | filter: notInTaboo">
                 <i class="icon-ok" ng-class="{'icon--hidden': !isSelected(item)}"></i>
                 <i class="{{ itemImage(item) }}" ng-if="itemImage"></i>
                 <div>{{ item }}</div>

--- a/resource/templates/custom-dropdown.html
+++ b/resource/templates/custom-dropdown.html
@@ -10,7 +10,7 @@
         <div class="custom-dropdown__body" ng-if="isOpen">
             <div class="custom-dropdown-row"
                 ng-click="updateSelection(item, $event)"
-                ng-repeat="item in possibleValues | filter: notInTaboo">
+                ng-repeat="item in possibleValues | filter: canBeSelected">
                 <i class="icon-ok" ng-class="{'icon--hidden': !isSelected(item)}"></i>
                 <i class="{{ itemImage(item) }}" ng-if="itemImage"></i>
                 <div>{{ item }}</div>

--- a/resource/templates/key-value-list.html
+++ b/resource/templates/key-value-list.html
@@ -1,28 +1,30 @@
 <div class="control-group">
-    <div class="key-value-list__labels flex">
-        <div class="key-value-list__labels_key">{{ keyLabel }}</div>
-        <div class="key-value-list__labels_value">{{ valueLabel }}</div>
-    </div>
-    <div class="key-value-list__elements">
-        <div class="flex key-value-element" ng-repeat="key in keys track by $index">
-            <div custom-dropdown
-                 form="form"
-                 item="keys[$index]"
-                 possible-values="keyOptions"
-                 item-name="{{ keyItemLabel }}"
-                 taboo="map"
-                 index="$index"
-                 class="key-value-element__key"></div>
-            <i class="icon-long-arrow-right"></i>
-            <input type="number"
-                   ng-model="map[keys[$index]]"
-                   ng-disabled="!keys[$index]"
-                   min="{{ valueMin }}"
-                   max="{{ valueMax }}"
-                   step="any"
-                   class="key-value-element__value" required>
-            </input>
-            <i class="icon-trash" ng-click="deleteListItem($index)" ng-class="{'icon--hidden': !$index}"></i>
+    <div class="key-value-list">
+        <div class="key-value-list__labels flex">
+            <div class="key-value-list__labels_key">{{ keyLabel }}</div>
+            <div class="key-value-list__labels_value">{{ valueLabel }}</div>
+        </div>
+        <div class="key-value-list__elements">
+            <div class="flex key-value-element" ng-repeat="key in keys track by $index">
+                <div custom-dropdown
+                    form="form"
+                    item="keys[$index]"
+                    possible-values="keyOptions"
+                    item-name="{{ keyItemLabel }}"
+                    taboo="map"
+                    index="$index"
+                    class="key-value-element__key"></div>
+                <i class="icon-long-arrow-right"></i>
+                <input type="number"
+                    ng-model="map[keys[$index]]"
+                    ng-disabled="!keys[$index]"
+                    min="{{ valueMin }}"
+                    max="{{ valueMax }}"
+                    step="any"
+                    class="key-value-element__value" required>
+                </input>
+                <i class="icon-trash" ng-click="deleteListItem($index)" ng-class="{'icon--hidden': !$index}"></i>
+            </div>
         </div>
     </div>
     <button type="button" class="dku-btn dku-btn--txt" ng-click="addListItem()">

--- a/resource/templates/key-value-list.html
+++ b/resource/templates/key-value-list.html
@@ -8,11 +8,11 @@
             <div class="flex key-value-element" ng-repeat="key in keys track by $index">
                 <div custom-dropdown
                     form="form"
-                    item="key"
+                    item="keys[$index]"
                     possible-values="keyOptions"
                     item-name="{{ keyItemLabel }}"
                     taboo="map"
-                    index="$index"
+                    on-change="dropdownChange"
                     validity="key-value-list-valid"
                     class="key-value-element__key"></div>
                 <i class="icon-long-arrow-right"></i>

--- a/resource/templates/key-value-list.html
+++ b/resource/templates/key-value-list.html
@@ -8,7 +8,7 @@
             <div class="flex key-value-element" ng-repeat="key in keys track by $index">
                 <div custom-dropdown
                     form="form"
-                    item="keys[$index]"
+                    item="key"
                     possible-values="keyOptions"
                     item-name="{{ keyItemLabel }}"
                     taboo="map"
@@ -17,14 +17,14 @@
                     class="key-value-element__key"></div>
                 <i class="icon-long-arrow-right"></i>
                 <input type="number"
-                    ng-model="map[keys[$index]]"
-                    ng-disabled="!keys[$index]"
+                    ng-model="map[key]"
+                    ng-disabled="!key"
                     min="{{ valueMin }}"
                     max="{{ valueMax }}"
                     step="any"
                     class="key-value-element__value" required>
                 </input>
-                <i class="icon-trash" ng-click="deleteListItem($index)" ng-class="{'icon--hidden': !$index}"></i>
+                <i class="icon-trash" ng-click="deleteListItem($index)" ng-class="{'icon--hidden': $first}"></i>
             </div>
         </div>
     </div>

--- a/resource/templates/key-value-list.html
+++ b/resource/templates/key-value-list.html
@@ -17,6 +17,8 @@
             <input type="number"
                    ng-model="map[keys[$index]]"
                    ng-disabled="!keys[$index]"
+                   min="{{ valueMin }}"
+                   max="{{ valueMax }}"
                    class="key-value-element__value" required>
             </input>
             <i class="icon-trash" ng-click="deleteListItem($index)" ng-class="{'icon--hidden': !$index}"></i>

--- a/resource/templates/key-value-list.html
+++ b/resource/templates/key-value-list.html
@@ -1,0 +1,29 @@
+<div class="control-group">
+    <div class="key-value-list__labels flex">
+        <div class="key-value-list__labels_key">{{ keyLabel }}</div>
+        <div class="key-value-list__labels_value">{{ valueLabel }}</div>
+    </div>
+    <div class="key-value-list__elements">
+        <div class="flex key-value-element" ng-repeat="key in keys track by $index">
+            <div custom-dropdown
+                 form="form"
+                 item="keys[$index]"
+                 possible-values="keyOptions"
+                 item-name="{{ keyItemLabel }}"
+                 taboo="map"
+                 index="$index"
+                 class="key-value-element__key"></div>
+            <i class="icon-long-arrow-right"></i>
+            <input type="number"
+                   ng-model="map[keys[$index]]"
+                   ng-disabled="!keys[$index]"
+                   class="key-value-element__value" required>
+            </input>
+            <i class="icon-trash" ng-click="deleteListItem($index)"></i>
+        </div>
+    </div>
+    <div class="dku-btn dku-btn--txt" ng-click="addListItem()">
+        <i class="icon-plus-sign"></i>
+        &nbsp;<span>Add feature</span>
+    </div>
+</div>

--- a/resource/templates/key-value-list.html
+++ b/resource/templates/key-value-list.html
@@ -28,7 +28,7 @@
             </div>
         </div>
     </div>
-    <button type="button" class="dku-btn dku-btn--txt" ng-click="addListItem()">
+    <button type="button" class="dku-btn dku-btn--txt" ng-disabled="!canAddListItem()" ng-click="addListItem()">
         <i class="icon-plus-sign"></i>
         &nbsp;<span>Add a {{ keyItemLabel }}</span>
     </button>

--- a/resource/templates/key-value-list.html
+++ b/resource/templates/key-value-list.html
@@ -21,7 +21,7 @@
                     ng-disabled="!key"
                     min="{{ valueMin }}"
                     max="{{ valueMax }}"
-                    step="any"
+                    step="{{ step }}"
                     class="key-value-element__value" required>
                 </input>
                 <i class="icon-trash" ng-click="deleteListItem($index)" ng-class="{'icon--hidden': $first}"></i>

--- a/resource/templates/key-value-list.html
+++ b/resource/templates/key-value-list.html
@@ -11,7 +11,7 @@
                     item="keys[$index]"
                     possible-values="keyOptions"
                     item-name="{{ keyItemLabel }}"
-                    taboo="map"
+                    not-available-values="map"
                     on-change="dropdownChange"
                     validity="key-value-list-valid"
                     class="key-value-element__key"></div>

--- a/resource/templates/key-value-list.html
+++ b/resource/templates/key-value-list.html
@@ -1,8 +1,8 @@
 <div class="control-group">
     <div class="key-value-list">
         <div class="key-value-list__labels flex">
-            <div class="key-value-list__labels_key">{{ keyLabel }}</div>
-            <div class="key-value-list__labels_value">{{ valueLabel }}</div>
+            <div class="key-value-label__key">{{ keyLabel }}</div>
+            <div class="key-value-label__value">{{ valueLabel }}</div>
         </div>
         <div class="key-value-list__elements">
             <div class="flex key-value-element" ng-repeat="key in keys track by $index">

--- a/resource/templates/key-value-list.html
+++ b/resource/templates/key-value-list.html
@@ -13,6 +13,7 @@
                     item-name="{{ keyItemLabel }}"
                     taboo="map"
                     index="$index"
+                    validity="key-value-list-valid"
                     class="key-value-element__key"></div>
                 <i class="icon-long-arrow-right"></i>
                 <input type="number"

--- a/resource/templates/key-value-list.html
+++ b/resource/templates/key-value-list.html
@@ -19,6 +19,7 @@
                    ng-disabled="!keys[$index]"
                    min="{{ valueMin }}"
                    max="{{ valueMax }}"
+                   step="any"
                    class="key-value-element__value" required>
             </input>
             <i class="icon-trash" ng-click="deleteListItem($index)" ng-class="{'icon--hidden': !$index}"></i>

--- a/resource/templates/key-value-list.html
+++ b/resource/templates/key-value-list.html
@@ -1,10 +1,10 @@
 <div class="control-group">
     <div class="key-value-list">
-        <div class="key-value-list__labels flex">
-            <div class="key-value-label__key">{{ keyLabel }}</div>
-            <div class="key-value-label__value">{{ valueLabel }}</div>
+        <div class="key-value-labels flex">
+            <div class="key-value-labels__key">{{ keyLabel }}</div>
+            <div class="key-value-labels__value">{{ valueLabel }}</div>
         </div>
-        <div class="key-value-list__elements">
+        <div>
             <div class="flex key-value-element" ng-repeat="key in keys track by $index">
                 <div custom-dropdown
                     form="form"

--- a/resource/templates/key-value-list.html
+++ b/resource/templates/key-value-list.html
@@ -19,11 +19,11 @@
                    ng-disabled="!keys[$index]"
                    class="key-value-element__value" required>
             </input>
-            <i class="icon-trash" ng-click="deleteListItem($index)"></i>
+            <i class="icon-trash" ng-click="deleteListItem($index)" ng-class="{'icon--hidden': !$index}"></i>
         </div>
     </div>
-    <div class="dku-btn dku-btn--txt" ng-click="addListItem()">
+    <button type="button" class="dku-btn dku-btn--txt" ng-click="addListItem()">
         <i class="icon-plus-sign"></i>
-        &nbsp;<span>Add feature</span>
-    </div>
+        &nbsp;<span>Add a {{ keyItemLabel }}</span>
+    </button>
 </div>

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -77,6 +77,7 @@
              item-name="feature"
              item-image="featureToTypeIcon"
              label="Corrupted features"
+             validity="dropdown-not-empty"
              class="settings-subsection__form_field">
         </div>
         <div class="control-group settings-subsection__form_field">
@@ -108,6 +109,7 @@
              item-name="feature"
              item-image="featureToTypeIcon"
              label="Corrupted features"
+             validity="dropdown-not-empty"
              class="settings-subsection__form_field">
         </div>
         <div class="control-group settings-subsection__form_field">

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -54,12 +54,6 @@
              form="forms.Rebalance"
              class="settings-subsection__form_field">
         </div>
-        <div class="control-group settings-subsection__form_field">
-            <label for="priorShift" class="label-text">Desired proportion of selected class</label>
-            <input type="number" id="priorShift"
-                   ng-model="tests.perturbations.Rebalance.params.samples_fraction"
-                   placeholder="0.5" step="0.01" min="0" max="1" required>
-        </div>
     </form>
 </div>
 

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -77,7 +77,6 @@
              item-name="feature"
              item-image="featureToTypeIcon"
              label="Corrupted features"
-             validity="dropdown-not-empty"
              class="settings-subsection__form_field">
         </div>
         <div class="control-group settings-subsection__form_field">
@@ -109,7 +108,6 @@
              item-name="feature"
              item-image="featureToTypeIcon"
              label="Corrupted features"
-             validity="dropdown-not-empty"
              class="settings-subsection__form_field">
         </div>
         <div class="control-group settings-subsection__form_field">

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -45,12 +45,15 @@
     </div>
     <form name="forms.Rebalance" class="settings-subsection__form"
           ng-show="tests.perturbations.Rebalance.$activated" ng-submit="runAnalysis()">
-        <div key-value-list map="tests.perturbations.Rebalance.params.priors"
+        <div key-value-list
+             map="tests.perturbations.Rebalance.params.priors"
              key-options="modelInfo.targetClasses"
              key-label="Target classes"
              key-item-label="class"
              value-label="Proportion"
              value-range="[0,1]"
+             step=".01"
+             default-value=".5"
              form="forms.Rebalance"
              class="settings-subsection__form_field">
         </div>

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -38,20 +38,14 @@
         <help-icon help-text="Modifies the target distribution by resampling"></help-icon>
     </div>
     <form name="forms.Rebalance" class="settings-subsection__form"
-          ng-show="tests.perturbations.Rebalance.$activated" ng-submit="runAnalysis()">
-        <div custom-dropdown
+          ng-if="tests.perturbations.Rebalance.$activated" ng-submit="runAnalysis()">
+        <div key-value-list map="tests.perturbations.Rebalance.params.priors"
+             key-options="modelInfo.targetClasses"
+             key-label="Target classes"
+             key-item-label="class"
+             value-label="Proportion"
              form="forms.Rebalance"
-             possible-values="modelInfo.targetClasses"
-             item="tests.perturbations.Rebalance.params.cl"
-             item-name="class"
-             label="Selected class"
              class="settings-subsection__form_field">
-        </div>
-        <div class="control-group settings-subsection__form_field">
-            <label for="priorShift" class="label-text">Desired proportion of samples with selected class</label>
-            <input type="number" id="priorShift"
-                   ng-model="tests.perturbations.Rebalance.params.samples_fraction"
-                   placeholder="0.5" step="0.01" min="0" max="1" required>
         </div>
     </form>
 </div>
@@ -68,7 +62,7 @@
         <help-icon help-text="Randomly inserts missing values"></help-icon>
     </div>
     <form name="forms.MissingValues" class="settings-subsection__form"
-          ng-show="tests.perturbations.MissingValues.$activated" ng-submit="runAnalysis()">
+          ng-if="tests.perturbations.MissingValues.$activated" ng-submit="runAnalysis()">
         <div custom-dropdown
              form="forms.MissingValues"
              possible-values="tests.perturbations.MissingValues.availableColumns"
@@ -99,7 +93,7 @@
         <help-icon help-text="Changes the order of magnitude of each feature by some random scaling"></help-icon>
     </div>
     <form name="forms.Scaling" class="settings-subsection__form"
-          ng-show="tests.perturbations.Scaling.$activated" ng-submit="runAnalysis()">
+          ng-if="tests.perturbations.Scaling.$activated" ng-submit="runAnalysis()">
         <div custom-dropdown
              form="forms.Scaling"
              possible-values="tests.perturbations.Scaling.availableColumns"

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -38,12 +38,13 @@
         <help-icon help-text="Modifies the target distribution by resampling"></help-icon>
     </div>
     <form name="forms.Rebalance" class="settings-subsection__form"
-          ng-if="tests.perturbations.Rebalance.$activated" ng-submit="runAnalysis()">
+          ng-show="tests.perturbations.Rebalance.$activated" ng-submit="runAnalysis()">
         <div key-value-list map="tests.perturbations.Rebalance.params.priors"
              key-options="modelInfo.targetClasses"
              key-label="Target classes"
              key-item-label="class"
              value-label="Proportion"
+             value-range="[0,1]"
              form="forms.Rebalance"
              class="settings-subsection__form_field">
         </div>
@@ -62,7 +63,7 @@
         <help-icon help-text="Randomly inserts missing values"></help-icon>
     </div>
     <form name="forms.MissingValues" class="settings-subsection__form"
-          ng-if="tests.perturbations.MissingValues.$activated" ng-submit="runAnalysis()">
+          ng-show="tests.perturbations.MissingValues.$activated" ng-submit="runAnalysis()">
         <div custom-dropdown
              form="forms.MissingValues"
              possible-values="tests.perturbations.MissingValues.availableColumns"
@@ -93,7 +94,7 @@
         <help-icon help-text="Changes the order of magnitude of each feature by some random scaling"></help-icon>
     </div>
     <form name="forms.Scaling" class="settings-subsection__form"
-          ng-if="tests.perturbations.Scaling.$activated" ng-submit="runAnalysis()">
+          ng-show="tests.perturbations.Scaling.$activated" ng-submit="runAnalysis()">
         <div custom-dropdown
              form="forms.Scaling"
              possible-values="tests.perturbations.Scaling.availableColumns"

--- a/webapps/stress-test-center-view/app.js
+++ b/webapps/stress-test-center-view/app.js
@@ -20,7 +20,7 @@ const versionId = webAppConfig['versionId'];
                 Rebalance: {
                     displayName: "Target distribution",
                     needsTargetClasses: true,
-                    params: { samples_fraction: .5 }
+                    params: { priors: {} }
                 },
                 MissingValues: {
                     displayName: "Missing values",
@@ -52,7 +52,7 @@ const versionId = webAppConfig['versionId'];
         }
 
         $scope.checkTestConfig = function() {
-            if ($scope.forms.SAMPLES.$invalid) return { canRun: false };
+            if (!$scope.forms.SAMPLES || $scope.forms.SAMPLES.$invalid) return { canRun: false };
             const testEntries = Object.entries($scope.tests.perturbations);
             const validActivatedTests = testEntries.filter(function(entry) {
                 const [testName, testSettings] = entry;

--- a/webapps/stress-test-center-view/style.css
+++ b/webapps/stress-test-center-view/style.css
@@ -306,11 +306,11 @@ transform: translate(-125%, -50%);
     margin-right: 16px;
 }
 
-.key-value-list__labels_key, .key-value-element__key {
+.key-value-label__key, .key-value-element__key {
     flex: 1 0 auto;
 }
 
-.key-value-list__labels_value, .key-value-element__value {
+.key-value-label__value, .key-value-element__value {
     flex: 0 1 75px;
 }
 

--- a/webapps/stress-test-center-view/style.css
+++ b/webapps/stress-test-center-view/style.css
@@ -207,13 +207,13 @@ transform: translate(-125%, -50%);
     color: var(--white);
 }
 
-.dku-btn-primary:disabled, .dku-btn-primary:active:hover {
+.dku-btn-primary:disabled, .dku-btn-primary:disabled:active {
     background: var(--blue-lighten-4);
     cursor: not-allowed;
 }
 
 .dku-btn-primary:active {
-    background: #3194fc;
+    background: var(--blue-darken-4);
 }
 
 .dku-btn-container--right-align {
@@ -228,7 +228,11 @@ transform: translate(-125%, -50%);
 }
 
 .dku-btn--txt:hover {
-    color: var(--blue-lighten-3);
+    background: var(--blue-lighten-5);
+}
+
+.dku-btn--txt:active {
+    background: var(--blue-lighten-4);
 }
 
 /** WEBAPP: GENERAL **/
@@ -308,6 +312,10 @@ transform: translate(-125%, -50%);
 
 .key-value-list__labels_value, .key-value-element__value {
     flex: 0 1 75px;
+}
+
+.key-value-list {
+    margin-bottom: 8px;
 }
 
 .key-value-element {

--- a/webapps/stress-test-center-view/style.css
+++ b/webapps/stress-test-center-view/style.css
@@ -354,7 +354,9 @@ transform: translate(-125%, -50%);
     left: 0;
     background: var(--white);
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-    width: 265px;
+    width: auto;
+    width: -moz-available;
+    width: -webkit-fill-available;
     max-height: 200px;
     z-index: 10;
 }

--- a/webapps/stress-test-center-view/style.css
+++ b/webapps/stress-test-center-view/style.css
@@ -235,6 +235,11 @@ transform: translate(-125%, -50%);
     background: var(--blue-lighten-4);
 }
 
+.dku-btn--txt:disabled {
+    color: var(--blue-lighten-4);
+    cursor: not-allowed;
+}
+
 /** WEBAPP: GENERAL **/
 
 .report-box {

--- a/webapps/stress-test-center-view/style.css
+++ b/webapps/stress-test-center-view/style.css
@@ -235,7 +235,7 @@ transform: translate(-125%, -50%);
     background: var(--blue-lighten-4);
 }
 
-.dku-btn--txt:disabled {
+.dku-btn--txt:disabled, .dku-btn--txt:disabled:active, .dku-btn--txt:disabled:hover {
     color: var(--blue-lighten-4);
     cursor: not-allowed;
 }

--- a/webapps/stress-test-center-view/style.css
+++ b/webapps/stress-test-center-view/style.css
@@ -46,9 +46,9 @@ form input[type="text"] {
     transition: color 0.1s ease, border-color 0.5s ease;
 }
 
-form input[type="number"].ng-invalid,
-form input[type="search"].ng-invalid,
-form input[type="text"].ng-invalid {
+form input[type="number"].ng-invalid:not(:disabled),
+form input[type="search"].ng-invalid:not(:disabled),
+form input[type="text"].ng-invalid:not(:disabled) {
     border-color: var(--error-red);
 }
 
@@ -221,6 +221,10 @@ transform: translate(-125%, -50%);
     justify-content: flex-end;
 }
 
+.dku-btn--txt {
+    color: var(--blue);
+}
+
 /** WEBAPP: GENERAL **/
 
 .report-box {
@@ -284,6 +288,45 @@ transform: translate(-125%, -50%);
 
 .webapp-section__settings .spinner-div {
     height: calc(100% - 210px);
+}
+
+/* Custom key value list */
+.key-value-list__labels {
+    justify-content: space-between;
+    margin-right: 16px;
+}
+
+.key-value-list__labels_key, .key-value-element__key {
+    flex: 1 0 auto;
+}
+
+.key-value-list__labels_value, .key-value-element__value {
+    flex: 0 1 75px;
+}
+
+.key-value-element {
+    align-items: center;
+}
+
+.key-value-element + .key-value-element {
+    margin-top: 8px;
+}
+
+.key-value-element > .icon-long-arrow-right {
+    margin: 0 8px;
+}
+
+.key-value-element > .icon-trash {
+    margin-left: 8px;
+}
+
+.icon-trash {
+    color: var(--error-red);
+}
+
+.icon-trash:hover {
+    opacity: .5;
+    cursor: pointer;
 }
 
 /* Custom dropdown */

--- a/webapps/stress-test-center-view/style.css
+++ b/webapps/stress-test-center-view/style.css
@@ -306,16 +306,16 @@ transform: translate(-125%, -50%);
 }
 
 /* Custom key value list */
-.key-value-list__labels {
+.key-value-labels {
     justify-content: space-between;
     margin-right: 16px;
 }
 
-.key-value-label__key, .key-value-element__key {
+.key-value-labels__key, .key-value-element__key {
     flex: 1 0 auto;
 }
 
-.key-value-label__value, .key-value-element__value {
+.key-value-labels__value, .key-value-element__value {
     flex: 0 1 75px;
 }
 

--- a/webapps/stress-test-center-view/style.css
+++ b/webapps/stress-test-center-view/style.css
@@ -238,6 +238,7 @@ transform: translate(-125%, -50%);
 .dku-btn--txt:disabled, .dku-btn--txt:disabled:active, .dku-btn--txt:disabled:hover {
     color: var(--blue-lighten-4);
     cursor: not-allowed;
+    background: none;
 }
 
 /** WEBAPP: GENERAL **/

--- a/webapps/stress-test-center-view/style.css
+++ b/webapps/stress-test-center-view/style.css
@@ -223,6 +223,12 @@ transform: translate(-125%, -50%);
 
 .dku-btn--txt {
     color: var(--blue);
+    background: none;
+    border: none;
+}
+
+.dku-btn--txt:hover {
+    color: var(--blue-lighten-3);
 }
 
 /** WEBAPP: GENERAL **/


### PR DESCRIPTION
[ch75555]
This PR allows for the user to input a target distribution for the target distribution stress test (usefull for multiclass). In practive, this mean switching from a single dropdown + a single number input, to a key value list with one or several dropdown-number input pairs.

A new frontend component has been added for a simplified key-value list, the UX is inspired by what we have in DSS (keys can only be a dropdown, values can only be number inputs).
<img width="292" alt="image" src="https://user-images.githubusercontent.com/22995764/144278589-fbea1aee-b41d-4d00-9583-643f50bf126d.png">
