### PR TITLE
Webapp: Add a warning in the metrics for not relevant tests

### DIFF
--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -155,6 +155,8 @@ class StressTestGenerator(object):
             perturbed_y_true, perturbed_y_pred, perturbed_probas = self._get_col_for_metrics(test.df_with_pred)
             perf_after = self._metric.compute(perturbed_y_true, perturbed_y_pred, perturbed_probas)
         else:
+            # Altered and unaltered datasets are the same, including the prediction columns.
+            # By definition, the performance is the same before and after the stress test.
             perf_after = perf_before
             common_metrics["not_relevant_explanation"] = test.not_relevant_explanation
         common_metrics.update({

--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -165,6 +165,8 @@ class StressTestGenerator(object):
         extra_metrics = {}
         if test.TEST_TYPE == DkuStressTestCenterConstants.FEATURE_PERTURBATION:
             if not test.relevant:
+                # Altered and unaltered datasets are the same, including the prediction columns.
+                # By definition, corruption resilience will hence always be 1.
                 corruption_resilience = 1
             elif self.model_accessor.get_prediction_type() == DkuStressTestCenterConstants.REGRESSION:
                 corruption_resilience = corruption_resilience_regression(

--- a/resource/templates/results-panel.html
+++ b/resource/templates/results-panel.html
@@ -56,7 +56,18 @@
                 </thead>
                 <tbody>
                     <tr ng-repeat="(testName, metrics) in results[corruptionType].metrics">
-                        <td class="cell">{{ tests.perturbations[testName].displayName }}</td>
+                        <td class="cell cell--with-tooltip">
+                            {{ tests.perturbations[testName].displayName }}
+                            <i class="icon-warning-sign icon--hoverable" ng-show="metrics.not_relevant_explanation"
+                               ng-mouseleave="showPredList[$index] = !showPredList[$index]"
+                               ng-mouseover="showPredList[$index] = !showPredList[$index]">
+                                <div class="details__tooltip" ng-show="showPredList[$index]">
+                                    <div>
+                                        Not relevant test: {{ metrics.not_relevant_explanation }}
+                                    </div>
+                                </div>
+                            </i>
+                        </td>
                         <td class="cell" ng-class="{'text-sb': !metric.contextual}" ng-repeat="metric in CORRUPTION_METRICS[corruptionType]">
                             {{ metrics[metric.name] | toFixedIfNeeded: 3 }}
                         </td>

--- a/resource/templates/results-panel.html
+++ b/resource/templates/results-panel.html
@@ -57,7 +57,7 @@
                 <tbody>
                     <tr ng-repeat="(testName, metrics) in results[corruptionType].metrics">
                         <td class="cell cell--with-tooltip">
-                            {{ tests.perturbations[testName].displayName }}
+                            {{ TEST_NAMES[testName] }}
                             <i class="icon-warning-sign icon--hoverable" ng-show="metrics.not_relevant_explanation"
                                ng-mouseleave="showPredList[$index] = !showPredList[$index]"
                                ng-mouseover="showPredList[$index] = !showPredList[$index]">

--- a/resource/templates/results-panel.html
+++ b/resource/templates/results-panel.html
@@ -59,9 +59,9 @@
                         <td class="cell cell--with-tooltip">
                             {{ TEST_NAMES[testName] }}
                             <i class="icon-warning-sign icon--hoverable" ng-show="metrics.not_relevant_explanation"
-                               ng-mouseleave="showPredList[$index] = !showPredList[$index]"
-                               ng-mouseover="showPredList[$index] = !showPredList[$index]">
-                                <div class="details__tooltip" ng-show="showPredList[$index]">
+                               ng-mouseleave="showNotRelevantWarning[testName] = !showNotRelevantWarning[testName]"
+                               ng-mouseover="showNotRelevantWarning[testName] = !showNotRelevantWarning[testName]">
+                                <div class="details__tooltip" ng-show="showNotRelevantWarning[testName]">
                                     <div>
                                         Not relevant test: {{ metrics.not_relevant_explanation }}
                                     </div>

--- a/resource/templates/settings-panel.html
+++ b/resource/templates/settings-panel.html
@@ -73,7 +73,7 @@
                     <input type="checkbox" ng-model="tests.perturbations.Rebalance.$activated">
                     <div class="slider round"></div>
                 </label>
-                <div>{{ tests.perturbations.Rebalance.displayName }}</div>
+                <div>{{ TEST_NAMES.Rebalance }}</div>
             </label>
             <help-icon help-text="Resample data to match a given target distribution"></help-icon>
         </div>
@@ -111,7 +111,7 @@
                     <input type="checkbox" ng-model="tests.perturbations.MissingValues.$activated">
                     <div class="slider round"></div>
                 </label>
-                <div>{{ tests.perturbations.MissingValues.displayName }}</div>
+                <div>{{ TEST_NAMES.MissingValues }}</div>
             </label>
             <help-icon help-text="Randomly inserts missing values in one or several feature columns"></help-icon>
         </div>
@@ -141,7 +141,7 @@
                     <input type="checkbox" ng-model="tests.perturbations.Scaling.$activated">
                     <div class="slider round"></div>
                 </label>
-                <div>{{ tests.perturbations.Scaling.displayName }}</div>
+                <div>{{ TEST_NAMES.Scaling }}</div>
             </label>
             <help-icon help-text="Multiplies one or several numerical features by a specified coefficient"></help-icon>
         </div>

--- a/webapps/stress-test-center-view/app.js
+++ b/webapps/stress-test-center-view/app.js
@@ -161,6 +161,7 @@ const versionId = webAppConfig['versionId'];
         $scope.createModal = ModalService.create($scope.modal);
 
         $scope.CORRUPTION_TYPES = CorruptionUtils.types;
+        $scope.TEST_NAMES = CorruptionUtils.TEST_NAMES;
         $scope.userFriendlyMetricName = MetricNames.longName
 
         $scope.loading = {};
@@ -168,18 +169,15 @@ const versionId = webAppConfig['versionId'];
         $scope.tests = {
             perturbations: {
                 Rebalance: {
-                    displayName: "Shift target distribution", // TODO: remove (use CorruptionUtils.TEST_NAMES instead)
                     needsTargetClasses: true,
                     params: { priors: {} }
                 },
                 MissingValues: {
-                    displayName: "Insert missing values",
                     allowedFeatureTypes: ["NUMERIC", "CATEGORY", "VECTOR", "TEXT"],
                     params: { samples_fraction: .5 },
                     selected_features: new Set()
                 },
                 Scaling: {
-                    displayName: "Multiply by a coefficient",
                     allowedFeatureTypes: ["NUMERIC"],
                     params: {
                         samples_fraction: .5,
@@ -247,7 +245,7 @@ const versionId = webAppConfig['versionId'];
                             result.critical_samples.predList = result.critical_samples.predList.map(function(predList) {
                                 predList = Object.entries(predList).map(function(pred) {
                                     const [testName, result] = pred;
-                                    return `${CorruptionUtils.TEST_NAMES[testName]}: ${$filter("toFixedIfNeeded")(result, 3)}`;
+                                    return `${$scope.TEST_NAMES[testName]}: ${$filter("toFixedIfNeeded")(result, 3)}`;
                                 });
                                 predList.unshift($scope.modelInfo.predType === 'REGRESSION' ? "Predicted values" : "True class probas");
                                 return predList;

--- a/webapps/stress-test-center-view/style.css
+++ b/webapps/stress-test-center-view/style.css
@@ -505,6 +505,15 @@ transform: translate(-125%, -50%);
     background: var(--white);
 }
 
+.icon-warning-sign {
+    color: var(--warning-orange);
+}
+
+.icon-warning-sign.icon--hoverable:hover {
+    color: #F6AF73;
+}
+
+
 /** RESULTS **/
 
 .results-section:not(:only-child) {
@@ -603,6 +612,10 @@ table {
 
  .cell {
     border: 1px solid var(--grey-lighten-6);
+ }
+
+ .cell--with-tooltip {
+    position: relative;
  }
 
  .top-cell--blue {

--- a/webapps/stress-test-center-view/style.css
+++ b/webapps/stress-test-center-view/style.css
@@ -493,6 +493,7 @@ transform: translate(-125%, -50%);
 }
 
 .details__tooltip {
+    z-index: 1000;
     font-family: var(--font-family);
     max-width: 400px;
     position: absolute;


### PR DESCRIPTION
[sc-77257]

This PR adds a ⚠️ icon next to the test name if the test is not relevant (i.e. the altered is the same as the unaltered dataset, so the metrics are of course "perfect").

<img width="617" alt="image" src="https://user-images.githubusercontent.com/22995764/148373288-3f2a2312-4637-4c2a-b086-67b2c2a167a5.png">
CI/CD ✅ 