### PR TITLE
Make model view py2 compatible

### DIFF
--- a/python-lib/model_metadata.py
+++ b/python-lib/model_metadata.py
@@ -10,5 +10,5 @@ def get_model_handler(model, version_id=None):
         return PredictionModelInformationHandler(params.split_desc, params.core_params, params.model_folder, params.model_folder)
     except Exception as e:
         if "ordinal not in range(128)" in safe_str(e):
-            raise Exception("Model stress test only supports models built with Python 3. This one was built with Python 2.") from None
+            raise Exception("Model stress test only supports models built with Python 3. This one was built with Python 2.")
         raise e

--- a/webapps/stress-test-center-view/backend.py
+++ b/webapps/stress-test-center-view/backend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import numpy as np
 import logging
 import traceback


### PR DESCRIPTION
[sc-94599]
This PR aims at making stress test center compatible with py3:
- remove coding pragma in `backend.py` (`# -*- coding: utf-8 -*-`), that made it impossible to open the webapp
- remove type hints in method declaration
- ensure divisions have a float denominator
- always use `safe_str` (instead of `str`)
- cast the result of `dict.keys()` to `set`, as in python 2 a list is returned
- use a binary operation between a `collections.Counter` and an empty `collections.Counter`, instead of the improper (in py2) unary operation `+` on the counter
- remove the `raise Exception(...) from ...` syntax
- avoid `list` & `dict` expansions (resp. `[ *xxx, *xxx]` & `{**xxx, **xxx}`)

CI passing on DSS11 plugin CI/CD instance