### PR TITLE
Fix error when some targets are unknown from the model

### DIFF
--- a/python-lib/dku_stress_test_center/model_accessor.py
+++ b/python-lib/dku_stress_test_center/model_accessor.py
@@ -4,7 +4,6 @@ import numpy as np
 from dku_stress_test_center.utils import DkuStressTestCenterConstants
 from dku_webapp import MISSING_VALUE
 from dku_stress_test_center.metrics import Metric
-from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
@@ -19,20 +18,17 @@ class ModelAccessor(object):
         """
         return self.model_handler.get_prediction_type()
 
-    @lru_cache
     def get_target_variable(self):
         """
         Return the name of the target variable
         """
         return self.model_handler.get_target_variable()
 
-    @lru_cache
     def get_target_classes(self):
         if self.get_prediction_type() == DkuStressTestCenterConstants.REGRESSION:
             return []
         return list(self.get_target_map().keys())
 
-    @lru_cache
     def get_target_map(self):
         return self.model_handler.get_target_map()
 
@@ -82,7 +78,6 @@ class ModelAccessor(object):
             return Metric.ROC_AUC
         return initial_evaluation_metric
 
-    @lru_cache
     def get_weight_variable(self):
         if self.model_handler.with_sample_weights():
             return self.model_handler.get_sample_weight_variable()

--- a/python-lib/dku_stress_test_center/model_accessor.py
+++ b/python-lib/dku_stress_test_center/model_accessor.py
@@ -4,6 +4,7 @@ import numpy as np
 from dku_stress_test_center.utils import DkuStressTestCenterConstants
 from dku_webapp import MISSING_VALUE
 from dku_stress_test_center.metrics import Metric
+from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
@@ -18,17 +19,20 @@ class ModelAccessor(object):
         """
         return self.model_handler.get_prediction_type()
 
+    @lru_cache
     def get_target_variable(self):
         """
         Return the name of the target variable
         """
         return self.model_handler.get_target_variable()
 
+    @lru_cache
     def get_target_classes(self):
         if self.get_prediction_type() == DkuStressTestCenterConstants.REGRESSION:
             return []
         return list(self.get_target_map().keys())
 
+    @lru_cache
     def get_target_map(self):
         return self.model_handler.get_target_map()
 
@@ -78,6 +82,7 @@ class ModelAccessor(object):
             return Metric.ROC_AUC
         return initial_evaluation_metric
 
+    @lru_cache
     def get_weight_variable(self):
         if self.model_handler.with_sample_weights():
             return self.model_handler.get_sample_weight_variable()

--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -249,7 +249,7 @@ class StressTestGenerator(object):
 
         target_map = self.model_accessor.get_target_map()
         target = self.model_accessor.get_target_variable()
-        df = df[df[target].isin(target_map.keys())]
+        df = df[df[target].isin(target_map)]
         
         self._clean_df = self.model_accessor.predict_and_concatenate(df)
         if self._clean_df.shape[0] == 0:

--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -246,6 +246,11 @@ class StressTestGenerator(object):
 
         df = self.model_accessor.get_original_test_df(sample_fraction=self._sampling_proportion,
                                                       random_state=self._random_state)
+
+        target_map = self.model_accessor.get_target_map()
+        target = self.model_accessor.get_target_variable()
+        df = df[df[target].isin(target_map.keys())]
+        
         self._clean_df = self.model_accessor.predict_and_concatenate(df)
         if self._clean_df.shape[0] == 0:
             raise ValueError(


### PR DESCRIPTION
Whenever the test set contains classes that are not in the training set, the tests crashed.
More generally, when this happens in the doctor during the preprocessing before training, the rows from the test dataset are discarded. Therefore we enforce the same behaviour in the stress test plugin.