### PR TITLE
Fix/handle text feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.1.2 - 2025-03-13
+- Fix issue when a missing handling method is not set
+- Fix issues with deprecated methods
+
 ## Version 1.1.1 - 2023-08-01
 - Fix model view always raising an error when running tests on a regression model
 - Ensure Run button properly disabled

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "model-stress-test",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "meta": {
         "label": "Model stress test",
         "category": "Machine Learning",

--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -55,7 +55,7 @@ class FeaturePerturbationTest(StressTest):
                 self.not_relevant_explanation = "The scaling factor is set to 1."
         elif type(self.shift) is MissingValues:
             for feature in self.features:
-                if preprocessing[feature].get("missing_handling", "") == "DROP_ROW":
+                if preprocessing[feature].get("missing_handling") == "DROP_ROW":
                     self.not_relevant_explanation = ("The feature '{}' drops ".format(feature) +\
                         "the rows with missing values and does not predict them.")
         else:

--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pandas as pd
+import numpy as np
 import warnings
 from collections import defaultdict
 from sklearn.exceptions import UndefinedMetricWarning
@@ -109,7 +110,7 @@ class SubpopulationShiftTest(StressTest):
     def perturb_df(self, df):
         df = df.copy()
         X = df.loc[:, df.columns != self.population].values
-        y = df.loc[:, self.population].replace({pd.np.nan: MISSING_VALUE}).values
+        y = df.loc[:, self.population].replace({np.nan: MISSING_VALUE}).values
 
         X, y = self.shift.transform(X, y)
         df.loc[:, df.columns != self.population] = X
@@ -325,7 +326,7 @@ class StressTestGenerator(object):
         critical_samples = self.model_accessor.get_original_test_df(
             sample_fraction=self._sampling_proportion,
             random_state=self._random_state
-        ).loc[indexes_to_keep, :].replace({pd.np.nan: ""})
+        ).loc[indexes_to_keep, :].replace({np.nan: ""})
 
         return {
             "uncertainties": critical_uncertainties,

--- a/python-lib/dku_stress_test_center/stress_test_center.py
+++ b/python-lib/dku_stress_test_center/stress_test_center.py
@@ -55,7 +55,7 @@ class FeaturePerturbationTest(StressTest):
                 self.not_relevant_explanation = "The scaling factor is set to 1."
         elif type(self.shift) is MissingValues:
             for feature in self.features:
-                if preprocessing[feature]["missing_handling"] == "DROP_ROW":
+                if preprocessing[feature].get("missing_handling", "") == "DROP_ROW":
                     self.not_relevant_explanation = ("The feature '{}' drops ".format(feature) +\
                         "the rows with missing values and does not predict them.")
         else:

--- a/python-lib/drift_dac/covariate_shift.py
+++ b/python-lib/drift_dac/covariate_shift.py
@@ -42,7 +42,7 @@ class MissingValues(Shift):
             X (numpy.ndarray): feature data.
             y (numpy.ndarray): target data.
         """
-        if X.dtype <= np.int and (self.value_to_put_in is None or isinstance(self.value_to_put_in, float)):
+        if X.dtype <= int and (self.value_to_put_in is None or isinstance(self.value_to_put_in, float)):
             Xt = X.astype(float)
         else:
             Xt = copy.deepcopy(X)
@@ -92,7 +92,7 @@ class Scaling(Shift):
             X (numpy.ndarray): feature data.
             y (numpy.ndarray): target data.
         """
-        if X.dtype <= np.int and isinstance(self.scaling_factor, float):
+        if X.dtype <= int and isinstance(self.scaling_factor, float):
             Xt = X.astype(float)
         else:
             Xt = copy.deepcopy(X)

--- a/resource/py/test_stress_center.py
+++ b/resource/py/test_stress_center.py
@@ -139,7 +139,7 @@ def test_compute_test_metrics(mocker, stress_test_generator, stress_test):
     np.testing.assert_array_equal(clean_probas, np.empty((6,0)))
     np.testing.assert_array_equal(corrup_probas, np.empty((5,0)))
     pd.testing.assert_series_equal(
-        clean_weights, pd.Series([pd.np.nan, "b", "b", pd.np.nan, "c", "g"], name="f3")
+        clean_weights, pd.Series([np.nan, "b", "b", np.nan, "c", "g"], name="f3")
     )
     pd.testing.assert_series_equal(
         corrup_weights, pd.Series(["b", "b", "b", "c", "g"], name="f3", index=[1,2,5,0,3])

--- a/tests/python/integration/requirements.txt
+++ b/tests/python/integration/requirements.txt
@@ -1,3 +1,3 @@
 pytest~=6.2
 dataiku-api-client
-git+git://github.com/dataiku/dataiku-plugin-tests-utils.git@master#egg=dataiku-plugin-tests-utils
+git+https://github.com/dataiku/dataiku-plugin-tests-utils.git@master#egg=dataiku-plugin-tests-utils


### PR DESCRIPTION
This PR adresses two issues with the plugin:
* The crash when a feature doesn't have a missing_handling attribute specified.
* The use of deprecated methods (pd.np.X, np.int)

To make the test run, I updated the URL of the plugin test package (the usage of a git protocol is deprecated on github)